### PR TITLE
Remove cloud-specific storage class references from docs

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -105,10 +105,10 @@ auth:
 storage:
   data:
     size: 100Gi
-    storageClass: gp3
+    # storageClass: ""  # Leave empty to use cluster default
   localStorage:
     size: 500Gi
-    storageClass: gp3
+    # storageClass: ""  # Leave empty to use cluster default
 
 # Resource limits
 resources:

--- a/docs/deployment/production-readiness.md
+++ b/docs/deployment/production-readiness.md
@@ -369,10 +369,10 @@ s3:
 storage:
   data:
     size: 100Gi
-    storageClass: gp3
+    # storageClass: ""  # Leave empty to use cluster default
   localStorage:
     size: 500Gi
-    storageClass: gp3
+    # storageClass: ""  # Leave empty to use cluster default
 
 resources:
   requests:

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -472,12 +472,12 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: encrypted-storage
-provisioner: kubernetes.io/aws-ebs
+provisioner: your-csi-driver       # Use your cluster's CSI driver
 parameters:
-  type: gp3
-  encrypted: 'true'
-  kmsKeyId: arn:aws:kms:us-east-1:123456789:key/xxx
+  encrypted: 'true'                # Provider-specific encryption parameter
 ```
+
+> **Note**: The `provisioner` and `parameters` depend on your cluster's storage backend (e.g., AWS EBS, Azure Disk, GCP PD, Ceph, etc.). Consult your provider's documentation for the correct values.
 
 ### 20. Encryption in Transit
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `gp3` storage class with commented-out defaults in Kubernetes deployment and production readiness docs
- Replace AWS-specific EBS provisioner and KMS references with generic CSI driver placeholders in security best practices
- Add note directing users to consult their provider's documentation for correct storage parameters

## Test plan
- [ ] Verify documentation renders correctly on GitHub
- [x] Confirm no remaining cloud-specific storage class references in examples