### PR TITLE
fix: proxy GitHub API calls through backend to respect CSP

### DIFF
--- a/backend/src/__tests__/routes/api/github/index.test.ts
+++ b/backend/src/__tests__/routes/api/github/index.test.ts
@@ -1,0 +1,108 @@
+import { FastifyInstance } from 'fastify';
+
+// Mock axios
+jest.mock('axios');
+
+// Mock config
+jest.mock('../../../../utils/config', () => ({
+  getProxyConfig: jest.fn().mockReturnValue({ httpProxy: '', httpsProxy: '' }),
+}));
+
+// Mock logAccess
+jest.mock('../../../../utils/logAccess', () => ({
+  logAccess: jest.fn(),
+}));
+
+describe('GitHub Routes', () => {
+  let fastify: FastifyInstance;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockedAxios: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // Reset modules to clear in-memory cache between tests
+    jest.resetModules();
+
+    // Re-require axios after resetModules to get the same mock instance
+    // that the route module will use
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    mockedAxios = require('axios') as jest.Mocked<typeof import('axios')>['default'];
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Fastify = require('fastify');
+    fastify = Fastify();
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const githubRoutes = require('../../../../routes/api/github').default;
+    await fastify.register(githubRoutes);
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  describe('GET /repo-info', () => {
+    it('should return stars and forks from GitHub API', async () => {
+      mockedAxios.get.mockResolvedValue({
+        data: {
+          stargazers_count: 42,
+          forks_count: 7,
+          full_name: 'rh-aiservices-bu/s4',
+        },
+      });
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/repo-info',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.stargazers_count).toBe(42);
+      expect(payload.forks_count).toBe(7);
+    });
+
+    it('should return cached data on subsequent requests', async () => {
+      mockedAxios.get.mockResolvedValue({
+        data: {
+          stargazers_count: 42,
+          forks_count: 7,
+        },
+      });
+
+      // First request - fetches from API
+      await fastify.inject({
+        method: 'GET',
+        url: '/repo-info',
+      });
+
+      // Second request - should use cache
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/repo-info',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.stargazers_count).toBe(42);
+      expect(payload.forks_count).toBe(7);
+
+      // axios.get should only be called once
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return 502 when GitHub API fails with no cache', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('Network error'));
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/repo-info',
+      });
+
+      expect(response.statusCode).toBe(502);
+      const payload = JSON.parse(response.payload);
+      expect(payload.error).toBeDefined();
+    });
+  });
+});

--- a/backend/src/routes/api/github/index.ts
+++ b/backend/src/routes/api/github/index.ts
@@ -1,0 +1,72 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import axios, { AxiosRequestConfig } from 'axios';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { getProxyConfig } from '../../../utils/config';
+import { handleError } from '../../../utils/errorHandler';
+import { HttpStatus } from '../../../utils/httpStatus';
+import { createLogger } from '../../../utils/logger';
+
+const logger = createLogger(undefined, '[GitHub]');
+
+const GITHUB_REPO_URL = 'https://api.github.com/repos/rh-aiservices-bu/s4';
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface GitHubRepoCache {
+  stargazers_count: number;
+  forks_count: number;
+  timestamp: number;
+}
+
+let cache: GitHubRepoCache | null = null;
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  fastify.get('/repo-info', async (req: FastifyRequest, reply: FastifyReply) => {
+    // Return cached data if still fresh
+    if (cache && Date.now() - cache.timestamp < CACHE_TTL_MS) {
+      return reply.send({
+        stargazers_count: cache.stargazers_count,
+        forks_count: cache.forks_count,
+      });
+    }
+
+    try {
+      const { httpsProxy } = getProxyConfig();
+      const axiosOptions: AxiosRequestConfig = {
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 's4-backend',
+        },
+        timeout: 10000,
+        proxy: false, // Disable axios default proxy handling
+      };
+
+      if (httpsProxy) {
+        axiosOptions.httpsAgent = new HttpsProxyAgent(httpsProxy);
+      }
+
+      const response = await axios.get(GITHUB_REPO_URL, axiosOptions);
+
+      cache = {
+        stargazers_count: response.data.stargazers_count,
+        forks_count: response.data.forks_count,
+        timestamp: Date.now(),
+      };
+
+      return reply.send({
+        stargazers_count: cache.stargazers_count,
+        forks_count: cache.forks_count,
+      });
+    } catch (error) {
+      // Stale-cache fallback: return old data if available
+      if (cache) {
+        logger.warn('GitHub API request failed, returning stale cache');
+        return reply.send({
+          stargazers_count: cache.stargazers_count,
+          forks_count: cache.forks_count,
+        });
+      }
+
+      await handleError(error, reply, HttpStatus.BAD_GATEWAY, req.log);
+    }
+  });
+};

--- a/backend/src/utils/authConfig.ts
+++ b/backend/src/utils/authConfig.ts
@@ -162,7 +162,7 @@ export const PUBLIC_ROUTES = ['/api/auth/info', '/api/auth/login'];
  * Routes that require exact match only to be public.
  * These are for health check endpoints that should not make their subpaths public.
  */
-export const PUBLIC_ROUTES_EXACT = ['/api'];
+export const PUBLIC_ROUTES_EXACT = ['/api', '/api/github/repo-info'];
 
 /**
  * Check if a URL path is a public route

--- a/backend/src/utils/errorHandler.ts
+++ b/backend/src/utils/errorHandler.ts
@@ -59,7 +59,7 @@ export async function handleS3Error(
 export async function handleError(
   error: unknown,
   reply: FastifyReply,
-  statusCode = HttpStatus.INTERNAL_SERVER_ERROR,
+  statusCode: number = HttpStatus.INTERNAL_SERVER_ERROR,
   logger?: { error: (msg: unknown) => void },
 ): Promise<void> {
   const sanitized = sanitizeErrorForLogging(error);

--- a/backend/src/utils/httpStatus.ts
+++ b/backend/src/utils/httpStatus.ts
@@ -36,6 +36,7 @@ export const HttpStatus = {
   CLIENT_CLOSED_REQUEST: 499, // Nginx extension for aborted requests
 
   // 5xx Server Errors
+  BAD_GATEWAY: 502,
   INTERNAL_SERVER_ERROR: 500,
   INSUFFICIENT_STORAGE: 507,
 } as const;

--- a/charts/s4/Chart.yaml
+++ b/charts/s4/Chart.yaml
@@ -3,7 +3,7 @@ name: s4
 description: S4 (Super Simple Storage Service) - A lightweight S3-compatible storage solution
 type: application
 version: 0.1.0
-appVersion: '0.2.0'
+appVersion: "0.2.1"
 keywords:
   - s3
   - storage

--- a/frontend/src/app/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/app/components/AppLayout/AppLayout.tsx
@@ -133,13 +133,13 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const currentLanguage = i18n.resolvedLanguage || 'en';
   const currentLngDisplay = supportedLngs[currentLanguage] || supportedLngs['en'];
 
-  // Fetch GitHub stars and forks
+  // Fetch GitHub stars and forks via backend proxy
   React.useEffect(() => {
-    fetch('https://api.github.com/repos/rh-aiservices-bu/s4')
-      .then((response) => response.json())
-      .then((data) => {
-        setRepoStars(data.stargazers_count);
-        setRepoForks(data.forks_count);
+    apiClient
+      .get('/github/repo-info')
+      .then((response) => {
+        setRepoStars(response.data.stargazers_count);
+        setRepoForks(response.data.forks_count);
       })
       .catch((error) => {
         // eslint-disable-next-line no-console

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s4",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Super Simple Storage Service - Lightweight S3 solution with web UI",
   "author": "Red Hat AI Services BU",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- **Added backend proxy route** (`GET /api/github/repo-info`) that fetches GitHub stars/forks server-side, with 1-hour in-memory cache and stale-cache fallback
- **Updated frontend** to use the backend proxy instead of calling `api.github.com` directly, which was blocked by Helmet CSP `connectSrc: 'self'` in production
- **Added route to public auth exclusion list** since the data is non-sensitive and cosmetic

## Test plan

- [x] Backend tests pass (3 new tests: success, caching, 502 on failure)
- [x] Full `npm run build` compiles cleanly (backend + frontend)
- [x] Frontend type-check and lint pass
- [x] Deploy to OpenShift and verify stars/forks appear in the sidebar
- [x] Verify no CSP violations in browser console