### PR TITLE
fix: disable HSTS header to prevent forced HTTPS redirects

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -112,6 +112,7 @@ app.register(fastifyCookie, {
 
 // Add security headers via Helmet
 app.register(helmet, {
+  strictTransportSecurity: false, // S4 runs behind a reverse proxy/ingress that handles TLS
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],


### PR DESCRIPTION
## Summary
- Disables helmet's default `strictTransportSecurity` (HSTS) header, which caused browsers to cache an HSTS policy and redirect all subsequent HTTP requests (JS, CSS, images) to HTTPS via 307 internal redirects
- S4 is designed to run behind a reverse proxy/ingress that handles TLS termination, so HSTS should not be set by the application itself

## Test plan
- [ ] Deploy container and access UI on port 5000 over HTTP
- [ ] Verify subsequent asset requests (JS, CSS, images) are not redirected to HTTPS
- [ ] Verify response headers no longer include `Strict-Transport-Security`