### PR TITLE
feat: add bucket notifications with webhook support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,12 @@ S4 runs as a single container with two processes managed by supervisord:
 s4/
 ├── backend/               # Fastify API server (TypeScript)
 │   └── src/
-│       ├── routes/api/    # API endpoints (buckets, objects, settings, etc.)
+│       ├── routes/api/    # API endpoints (buckets, objects, notifications, settings, etc.)
 │       ├── plugins/       # Auto-loaded Fastify plugins (auth)
 │       ├── config/        # CORS configuration
 │       ├── schemas/       # Request validation schemas
 │       ├── types.ts       # TypeScript type definitions
-│       ├── utils/         # Configuration, helpers
+│       ├── utils/         # Configuration, helpers, notifications
 │       ├── __tests__/     # Jest tests
 │       ├── app.ts         # Fastify app initialization
 │       └── server.ts      # Entry point

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For detailed instructions on using S4 — browsing storage, managing buckets, tr
 - **Object Operations** - Upload, download, browse, and delete objects
 - **Standard Filesystem Operations** - Browse and manage mounted filesystem/PVC storage
 - **Cross-Storage Transfers** - Transfer files between storage locations in any combination (S3 ↔ PVC, S3 ↔ S3, PVC ↔ PVC)
+- **Bucket Notifications** - Webhook-based notifications for object changes (create, modify, delete)
 - **HuggingFace Integration** - Direct model import from HuggingFace Hub
 
 ## Documentation

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -115,6 +115,20 @@ JWT_SECRET=your-secret-key-change-in-production
 
 
 # ===================================
+# Notifications Configuration
+# ===================================
+
+# Path to JSON file storing notification configs
+# Default (container): /var/lib/ceph/radosgw/db/notifications.json
+# For development, point to your mounted Ceph data directory
+# NOTIFICATION_STORE_PATH=/path/to/your/rgw-data/db/notifications.json
+
+# Path to Ceph POSIX backend bucket data directory (used by filesystem watcher)
+# Default (container): /var/lib/ceph/radosgw/buckets
+# For development, point to your mounted Ceph data directory
+# BUCKET_DATA_PATH=/path/to/your/rgw-data/buckets
+
+# ===================================
 # Logging & Debugging Configuration
 # ===================================
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -111,9 +111,9 @@ fastify.get('/:bucketName/:encodedKey', async (req: TypedRequest<ObjectParams, O
 
 **Available Types**:
 
-- **Params**: `BucketParams`, `ObjectParams`, `TransferJobParams`, `LocationParams`
+- **Params**: `BucketParams`, `ObjectParams`, `TransferJobParams`, `LocationParams`, `NotificationParams`
 - **Query**: `ObjectQueryParams`, `LocalQueryParams`
-- **Body**: `CreateBucketBody`, `S3ConfigBody`, `TransferRequestBody`, etc.
+- **Body**: `CreateBucketBody`, `S3ConfigBody`, `TransferRequestBody`, `NotificationConfigBody`, `TestEndpointBody`, etc.
 
 **Justified `as any` Usage**:
 
@@ -127,7 +127,8 @@ fastify.get('/:bucketName/:encodedKey', async (req: TypedRequest<ObjectParams, O
 
 - **Local filesystem storage** - `/api/local/*` routes provide file operations on configured local paths (`LOCAL_STORAGE_PATHS`)
 - **File type validation** - Configurable allowed/blocked extensions (`utils/fileValidation.ts`)
-- **Audit logging** - Structured audit events for auth, storage, and transfer operations (`utils/auditLog.ts`)
+- **Audit logging** - Structured audit events for auth, storage, transfer, and notification operations (`utils/auditLog.ts`)
+- **Bucket notifications** - Webhook-based event notifications via filesystem watching (`routes/api/notifications/`, `utils/notificationStore.ts`, `utils/bucketWatcher.ts`, `utils/webhookDispatcher.ts`)
 - **Transfer queue** - Managed concurrent cross-storage transfers with progress tracking (`utils/transferQueue.ts`)
 - **Path prefix routing** - `NB_PREFIX` support for gateway/ingress deployments
 
@@ -277,6 +278,8 @@ fastify.post('/', { schema: createBucketSchema }, async (req, reply) => {
 - `updateProxyConfigSchema` - Proxy settings
 - `updateHFConfigSchema` - HuggingFace token
 - `transferRequestSchema` - Transfer job creation
+- `putNotificationsSchema` - Notification configuration
+- `testEndpointSchema` - Notification endpoint testing
 
 **Location**: `backend/src/schemas/index.ts`
 
@@ -370,6 +373,7 @@ API routes are organized under `/api/*` and auto-loaded from `src/routes/api/`:
 - `/api/objects` - S3 object operations (upload, download, list, delete, tags, metadata)
 - `/api/settings` - Configuration management (S3, HuggingFace, proxy, concurrency, pagination)
 - `/api/disclaimer` - Application metadata
+- `/api/notifications` - Bucket notification management (webhooks via filesystem watching)
 - `/api/transfer` - Cross-storage transfer operations and SSE progress
 - `/api/local/*` - Local filesystem storage operations (list, upload, download, mkdir, delete)
 
@@ -447,7 +451,7 @@ backend/
 │   ├── config/           # CORS configuration
 │   ├── schemas/          # Request validation schemas
 │   ├── types.ts          # TypeScript type definitions
-│   ├── utils/            # Config, logging, constants, validation, audit
+│   ├── utils/            # Config, logging, constants, validation, audit, notifications
 │   ├── __tests__/        # Jest tests
 │   ├── app.ts            # Fastify app initialization, global auth hook
 │   └── server.ts         # Server entry point
@@ -497,6 +501,11 @@ Key configuration for backend development (see [Configuration Reference](../docs
 **SSE**:
 
 - `SSE_TICKET_TTL_SECONDS` (default: 60) - One-time SSE ticket lifetime
+
+**Notifications**:
+
+- `NOTIFICATION_STORE_PATH` (default: `/var/lib/ceph/radosgw/db/notifications.json`) - Path to JSON file storing notification configs
+- `BUCKET_DATA_PATH` (default: `/var/lib/ceph/radosgw/buckets`) - Path to Ceph POSIX backend bucket data directory
 
 **Routing**:
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "s4-backend",
-  "version": "0.1.0",
+  "version": "0.0.0-see-root",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "s4-backend",
-      "version": "0.1.0",
+      "version": "0.0.0-see-root",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.787.0",
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.1.tgz",
-      "integrity": "sha512-sIyFcoPZkTtNu9xFeEoynMef3bPJIAbOfUh+ueYcfhVl6xm2VRtMcMclSxmZCMnHHd4hlYKJeq/aggmBEWynww==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -2976,12 +2976,12 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
-      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
+      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3014,16 +3014,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
-      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
+      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3031,18 +3031,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.5.tgz",
-      "integrity": "sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
+      "integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.12",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -3052,15 +3052,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
-      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
+      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3138,14 +3138,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
-      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
+      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
@@ -3169,12 +3169,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
-      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
+      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -3198,12 +3198,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
-      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
+      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3237,13 +3237,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
-      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
+      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3251,18 +3251,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.12.tgz",
-      "integrity": "sha512-9pAX/H+VQPzNbouhDhkW723igBMLgrI8OtX+++M7iKJgg/zY/Ig3i1e6seCcx22FWhE6Q/S61BRdi2wXBORT+A==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
+      "integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.5",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/core": "^3.23.2",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3270,18 +3270,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.12.tgz",
-      "integrity": "sha512-S4kWNKFowYd0lID7/DBqWHOQxmxlsf0jBaos9chQZUWTVOjSW1Ogyh8/ib5tM+agFDJ/TCxuCTvrnlc+9cIBcQ==",
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
+      "integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
@@ -3290,13 +3290,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
+      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3304,12 +3304,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
-      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
+      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3317,14 +3317,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
-      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
+      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3332,15 +3332,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
-      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
+      "integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3348,12 +3348,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
-      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
+      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3361,12 +3361,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
+      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3374,12 +3374,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
+      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -3388,12 +3388,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
-      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
+      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3401,24 +3401,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
-      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
+      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0"
+        "@smithy/types": "^4.12.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
-      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
+      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3426,16 +3426,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
-      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
+      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-uri-escape": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -3445,17 +3445,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.9.8",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.8.tgz",
-      "integrity": "sha512-8xgq3LgKDEFoIrLWBho/oYKyWByw9/corz7vuh1upv7ZBm0ZMjGYBhbn6v643WoIqA9UTcx5A5htEp/YatUwMA==",
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
+      "integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.5",
-        "@smithy/middleware-endpoint": "^4.3.12",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-stream": "^4.5.6",
+        "@smithy/core": "^3.23.2",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3463,9 +3463,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
-      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3475,13 +3475,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
-      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
+      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/querystring-parser": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3552,14 +3552,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.11.tgz",
-      "integrity": "sha512-yHv+r6wSQXEXTPVCIQTNmXVWs7ekBTpMVErjqZoWkYN75HIFN5y9+/+sYOejfAuvxWGvgzgxbTHa/oz61YTbKw==",
+      "version": "4.3.32",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
+      "integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3567,17 +3567,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.14.tgz",
-      "integrity": "sha512-ljZN3iRvaJUgulfvobIuG97q1iUuCMrvXAlkZ4msY+ZuVHQHDIqn7FKZCEj+bx8omz6kF5yQXms/xhzjIO5XiA==",
+      "version": "4.2.35",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
+      "integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3585,13 +3585,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
-      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
+      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3611,12 +3611,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
-      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
+      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3624,13 +3624,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
-      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
+      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3638,14 +3638,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
-      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
+      "integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",

--- a/backend/src/__tests__/routes/api/notifications/index.test.ts
+++ b/backend/src/__tests__/routes/api/notifications/index.test.ts
@@ -1,0 +1,302 @@
+import { FastifyInstance } from 'fastify';
+import notificationsRoutes from '../../../../routes/api/notifications';
+
+// Mock logAccess
+jest.mock('../../../../utils/logAccess', () => ({
+  logAccess: jest.fn(),
+}));
+
+// Mock error handler
+jest.mock('../../../../utils/errorHandler', () => ({
+  handleError: jest.fn(
+    async (_error: unknown, reply: { code: (n: number) => { send: (body: unknown) => void } }, statusCode: number) => {
+      reply.code(statusCode).send({ error: 'InternalServerError', message: 'An error occurred' });
+    },
+  ),
+}));
+
+// Mock notification store (async functions)
+jest.mock('../../../../utils/notificationStore', () => ({
+  getNotifications: jest.fn().mockResolvedValue([]),
+  setNotifications: jest.fn().mockResolvedValue(undefined),
+  deleteNotification: jest.fn().mockResolvedValue(true),
+  getAllBucketNames: jest.fn().mockResolvedValue([]),
+}));
+
+// Mock bucket watcher
+jest.mock('../../../../utils/bucketWatcher', () => ({
+  startWatching: jest.fn(),
+  stopWatching: jest.fn(),
+  initializeWatchers: jest.fn().mockResolvedValue(undefined),
+  shutdownWatchers: jest.fn(),
+}));
+
+// Mock axios for test-endpoint
+jest.mock('axios', () => ({
+  post: jest.fn(),
+}));
+
+import { getNotifications, setNotifications, deleteNotification } from '../../../../utils/notificationStore';
+import { startWatching, stopWatching } from '../../../../utils/bucketWatcher';
+import axios from 'axios';
+
+describe('Notification Routes', () => {
+  let fastify: FastifyInstance;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Fastify = require('fastify');
+    fastify = Fastify();
+    fastify.register(notificationsRoutes);
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    jest.clearAllMocks();
+  });
+
+  describe('GET /:bucketName', () => {
+    it('should return empty notifications when none configured', async () => {
+      (getNotifications as jest.Mock).mockResolvedValue([]);
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/test-bucket',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.notifications).toEqual([]);
+      expect(getNotifications).toHaveBeenCalledWith('test-bucket');
+    });
+
+    it('should return notification list from store', async () => {
+      (getNotifications as jest.Mock).mockResolvedValue([
+        {
+          id: 'notif-1',
+          endpoint: 'http://example.com/webhook',
+          events: ['s3:ObjectCreated:*'],
+          prefix: 'uploads/',
+          suffix: '.jpg',
+        },
+      ]);
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/test-bucket',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.notifications).toHaveLength(1);
+      expect(payload.notifications[0]).toEqual({
+        id: 'notif-1',
+        endpoint: 'http://example.com/webhook',
+        events: ['s3:ObjectCreated:*'],
+        prefix: 'uploads/',
+        suffix: '.jpg',
+      });
+    });
+
+    it('should reject invalid bucket names', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/INVALID_BUCKET',
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe('PUT /:bucketName', () => {
+    it('should save notifications and start watcher', async () => {
+      const response = await fastify.inject({
+        method: 'PUT',
+        url: '/test-bucket',
+        payload: {
+          notifications: [
+            {
+              id: 'notif-1',
+              endpoint: 'http://example.com/webhook',
+              events: ['s3:ObjectCreated:*'],
+              prefix: 'uploads/',
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.message).toBe('Notification configuration updated successfully');
+      expect(setNotifications).toHaveBeenCalledWith('test-bucket', [
+        expect.objectContaining({
+          id: 'notif-1',
+          endpoint: 'http://example.com/webhook',
+          events: ['s3:ObjectCreated:*'],
+          prefix: 'uploads/',
+        }),
+      ]);
+      expect(startWatching).toHaveBeenCalledWith('test-bucket');
+    });
+
+    it('should validate endpoint URL format', async () => {
+      const response = await fastify.inject({
+        method: 'PUT',
+        url: '/test-bucket',
+        payload: {
+          notifications: [
+            {
+              endpoint: 'ftp://invalid.com',
+              events: ['s3:ObjectCreated:*'],
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should validate event types', async () => {
+      const response = await fastify.inject({
+        method: 'PUT',
+        url: '/test-bucket',
+        payload: {
+          notifications: [
+            {
+              endpoint: 'http://example.com/webhook',
+              events: ['s3:InvalidEvent'],
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe('DELETE /:bucketName/:notificationId', () => {
+    it('should remove notification from store', async () => {
+      (deleteNotification as jest.Mock).mockResolvedValue(true);
+      (getNotifications as jest.Mock).mockResolvedValue([
+        {
+          id: 'notif-2',
+          endpoint: 'http://example.com/webhook2',
+          events: ['s3:ObjectRemoved:*'],
+        },
+      ]);
+
+      const response = await fastify.inject({
+        method: 'DELETE',
+        url: '/test-bucket/notif-1',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.message).toBe('Notification removed successfully');
+      expect(deleteNotification).toHaveBeenCalledWith('test-bucket', 'notif-1');
+    });
+
+    it('should stop watcher when no notifications remain', async () => {
+      (deleteNotification as jest.Mock).mockResolvedValue(true);
+      (getNotifications as jest.Mock).mockResolvedValue([]);
+
+      const response = await fastify.inject({
+        method: 'DELETE',
+        url: '/test-bucket/notif-1',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(deleteNotification).toHaveBeenCalledWith('test-bucket', 'notif-1');
+      expect(stopWatching).toHaveBeenCalledWith('test-bucket');
+    });
+
+    it('should return 404 when notification does not exist', async () => {
+      (deleteNotification as jest.Mock).mockResolvedValue(false);
+
+      const response = await fastify.inject({
+        method: 'DELETE',
+        url: '/test-bucket/nonexistent',
+      });
+
+      expect(response.statusCode).toBe(404);
+      const payload = JSON.parse(response.payload);
+      expect(payload.error).toBe('NotFound');
+    });
+  });
+
+  describe('POST /test-endpoint', () => {
+    it('should return success for reachable endpoint', async () => {
+      (axios.post as jest.Mock).mockResolvedValue({
+        status: 200,
+        data: 'OK',
+      });
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/test-endpoint',
+        payload: {
+          endpoint: 'http://example.com/webhook',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.success).toBe(true);
+      expect(payload.statusCode).toBe(200);
+      expect(payload.warning).toBeUndefined();
+    });
+
+    it('should include warning for non-2xx status', async () => {
+      (axios.post as jest.Mock).mockResolvedValue({
+        status: 500,
+        data: 'Internal Server Error',
+      });
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/test-endpoint',
+        payload: {
+          endpoint: 'http://example.com/webhook',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const payload = JSON.parse(response.payload);
+      expect(payload.success).toBe(true);
+      expect(payload.statusCode).toBe(500);
+      expect(payload.warning).toContain('non-success status');
+    });
+
+    it('should return failure for unreachable endpoint', async () => {
+      (axios.post as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/test-endpoint',
+        payload: {
+          endpoint: 'http://unreachable.example.com/webhook',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const payload = JSON.parse(response.payload);
+      expect(payload.success).toBe(false);
+      expect(payload.message).toContain('ECONNREFUSED');
+    });
+
+    it('should validate endpoint URL format', async () => {
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/test-endpoint',
+        payload: {
+          endpoint: 'not-a-url',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/backend/src/routes/api/buckets/index.ts
+++ b/backend/src/routes/api/buckets/index.ts
@@ -7,6 +7,8 @@ import { createBucketSchema } from '../../../schemas';
 import { BucketParams, CreateBucketBody } from '../../../types';
 import { handleS3Error } from '../../../utils/errorHandler';
 import { auditLogExtended, AuditEventType } from '../../../utils/auditLog';
+import { setNotifications } from '../../../utils/notificationStore';
+import { stopWatching } from '../../../utils/bucketWatcher';
 
 export default async (fastify: FastifyInstance): Promise<void> => {
   // Note: Authentication is handled by the global auth hook in app.ts
@@ -93,6 +95,10 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     logAccess(req);
     const { s3Client } = getS3Config();
     const { bucketName } = req.params;
+
+    // Clean up notification configs and watcher before deleting the bucket
+    stopWatching(bucketName);
+    await setNotifications(bucketName, []);
 
     const deleteBucketCommand = new DeleteBucketCommand({
       Bucket: bucketName,

--- a/backend/src/routes/api/notifications/index.ts
+++ b/backend/src/routes/api/notifications/index.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from 'crypto';
+import { FastifyInstance } from 'fastify';
+import axios from 'axios';
+
+import { logAccess } from '../../../utils/logAccess';
+import {
+  getNotificationsSchema,
+  putNotificationsSchema,
+  deleteNotificationSchema,
+  testEndpointSchema,
+} from '../../../schemas';
+import { BucketParams, NotificationParams, NotificationConfigBody, TestEndpointBody } from '../../../types';
+import { HttpStatus } from '../../../utils/httpStatus';
+import { handleError } from '../../../utils/errorHandler';
+import { auditLogExtended, AuditEventType } from '../../../utils/auditLog';
+import { getNotifications, setNotifications, deleteNotification } from '../../../utils/notificationStore';
+import { startWatching, stopWatching, initializeWatchers } from '../../../utils/bucketWatcher';
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  // Initialize watchers after the server is ready
+  fastify.addHook('onReady', async () => {
+    await initializeWatchers();
+  });
+
+  /**
+   * GET /:bucketName - Get notification configurations for a bucket
+   *
+   * Returns the current notification configuration from the local store.
+   */
+  fastify.get<{ Params: BucketParams }>('/:bucketName', { schema: getNotificationsSchema }, async (req, reply) => {
+    logAccess(req);
+    const { bucketName } = req.params;
+
+    try {
+      const notifications = await getNotifications(bucketName);
+      reply.send({ notifications });
+    } catch (error) {
+      await handleError(error, reply, HttpStatus.INTERNAL_SERVER_ERROR, req.log);
+    }
+  });
+
+  /**
+   * PUT /:bucketName - Set notification configurations for a bucket
+   *
+   * Saves notification entries to local store and starts filesystem watcher.
+   */
+  fastify.put<{ Params: BucketParams; Body: NotificationConfigBody }>(
+    '/:bucketName',
+    { schema: putNotificationsSchema },
+    async (req, reply) => {
+      logAccess(req);
+      const { bucketName } = req.params;
+      const { notifications } = req.body;
+
+      try {
+        // Assign IDs to entries that don't have one
+        const withIds = notifications.map((entry) => ({
+          ...entry,
+          id: entry.id || randomUUID(),
+        }));
+
+        await setNotifications(bucketName, withIds);
+        startWatching(bucketName);
+
+        // Audit log
+        if (req.user) {
+          auditLogExtended({
+            user: req.user,
+            eventType: AuditEventType.NOTIFICATION_CREATE,
+            action: 'create',
+            resource: `notification:${bucketName}`,
+            status: 'success',
+            details: `Set ${notifications.length} notification(s)`,
+            clientIp: req.ip || 'unknown',
+          });
+        }
+
+        reply.send({ message: 'Notification configuration updated successfully' });
+      } catch (error) {
+        await handleError(error, reply, HttpStatus.INTERNAL_SERVER_ERROR, req.log);
+      }
+    },
+  );
+
+  /**
+   * DELETE /:bucketName/:notificationId - Remove a single notification
+   *
+   * Removes the matching entry from the store and stops the watcher
+   * if no notifications remain for this bucket.
+   */
+  fastify.delete<{ Params: NotificationParams }>(
+    '/:bucketName/:notificationId',
+    { schema: deleteNotificationSchema },
+    async (req, reply) => {
+      logAccess(req);
+      const { bucketName, notificationId } = req.params;
+
+      try {
+        const deleted = await deleteNotification(bucketName, notificationId);
+
+        if (!deleted) {
+          reply.code(HttpStatus.NOT_FOUND).send({ error: 'NotFound', message: 'Notification not found' });
+          return;
+        }
+
+        // Stop watcher if no notifications remain for this bucket
+        const remaining = await getNotifications(bucketName);
+        if (remaining.length === 0) {
+          stopWatching(bucketName);
+        }
+
+        // Audit log
+        if (req.user) {
+          auditLogExtended({
+            user: req.user,
+            eventType: AuditEventType.NOTIFICATION_DELETE,
+            action: 'delete',
+            resource: `notification:${bucketName}/${notificationId}`,
+            status: 'success',
+            clientIp: req.ip || 'unknown',
+          });
+        }
+
+        reply.send({ message: 'Notification removed successfully' });
+      } catch (error) {
+        await handleError(error, reply, HttpStatus.INTERNAL_SERVER_ERROR, req.log);
+      }
+    },
+  );
+
+  /**
+   * POST /test-endpoint - Test an HTTP endpoint by sending a sample S3 event
+   *
+   * Sends a sample S3 notification event to the provided URL and reports
+   * whether the endpoint is reachable and responsive.
+   */
+  fastify.post<{ Body: TestEndpointBody }>('/test-endpoint', { schema: testEndpointSchema }, async (req, reply) => {
+    logAccess(req);
+    const { endpoint } = req.body;
+
+    const sampleEvent = {
+      Records: [
+        {
+          eventVersion: '2.1',
+          eventSource: 'aws:s3',
+          eventName: 's3:TestEvent',
+          eventTime: new Date().toISOString(),
+          s3: {
+            bucket: { name: 'test-bucket' },
+            object: { key: 'test-object.txt', size: 0 },
+          },
+        },
+      ],
+    };
+
+    try {
+      const response = await axios.post(endpoint, sampleEvent, {
+        timeout: 5000,
+        headers: { 'Content-Type': 'application/json' },
+        validateStatus: () => true, // Accept any HTTP status
+      });
+
+      const isSuccess = response.status >= 200 && response.status < 300;
+
+      // Audit log
+      if (req.user) {
+        auditLogExtended({
+          user: req.user,
+          eventType: AuditEventType.NOTIFICATION_TEST,
+          action: 'test',
+          resource: `notification:endpoint`,
+          status: 'success',
+          details: `Endpoint ${endpoint} responded with status ${response.status}`,
+          clientIp: req.ip || 'unknown',
+        });
+      }
+
+      reply.send({
+        success: true,
+        statusCode: response.status,
+        message: `Endpoint responded with status ${response.status}`,
+        warning: !isSuccess ? `Endpoint returned non-success status ${response.status}` : undefined,
+      });
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : 'Unknown error';
+
+      if (req.user) {
+        auditLogExtended({
+          user: req.user,
+          eventType: AuditEventType.NOTIFICATION_TEST,
+          action: 'test',
+          resource: `notification:endpoint`,
+          status: 'failure',
+          details: `Endpoint ${endpoint} failed: ${errMsg}`,
+          clientIp: req.ip || 'unknown',
+        });
+      }
+
+      reply.code(HttpStatus.BAD_REQUEST).send({
+        success: false,
+        message: `Failed to reach endpoint: ${errMsg}`,
+      });
+    }
+  });
+};

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -198,6 +198,91 @@ export const conflictCheckRequestSchema = {
   },
 };
 
+// ========== Notification Schemas ==========
+
+const bucketNameParam = {
+  type: 'string',
+  minLength: 3,
+  maxLength: 63,
+  pattern: '^[a-z0-9][a-z0-9-]*[a-z0-9]$',
+};
+
+export const getNotificationsSchema = {
+  params: {
+    type: 'object',
+    required: ['bucketName'],
+    properties: {
+      bucketName: bucketNameParam,
+    },
+  },
+};
+
+export const deleteNotificationSchema = {
+  params: {
+    type: 'object',
+    required: ['bucketName', 'notificationId'],
+    properties: {
+      bucketName: bucketNameParam,
+      notificationId: { type: 'string', minLength: 1 },
+    },
+  },
+};
+
+export const putNotificationsSchema = {
+  params: {
+    type: 'object',
+    required: ['bucketName'],
+    properties: {
+      bucketName: bucketNameParam,
+    },
+  },
+  body: {
+    type: 'object',
+    required: ['notifications'],
+    properties: {
+      notifications: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['endpoint', 'events'],
+          properties: {
+            id: { type: 'string' },
+            endpoint: {
+              type: 'string',
+              pattern: '^https?://.+',
+              minLength: 1,
+            },
+            events: {
+              type: 'array',
+              minItems: 1,
+              items: {
+                type: 'string',
+                enum: ['s3:ObjectCreated:*', 's3:ObjectRemoved:*'],
+              },
+            },
+            prefix: { type: 'string' },
+            suffix: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const testEndpointSchema = {
+  body: {
+    type: 'object',
+    required: ['endpoint'],
+    properties: {
+      endpoint: {
+        type: 'string',
+        pattern: '^https?://.+',
+        minLength: 1,
+      },
+    },
+  },
+};
+
 // ========== Object Metadata/Tagging Schemas ==========
 
 export const putObjectTagsSchema = {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -135,3 +135,25 @@ export interface ObjectTag {
 export interface ObjectTagsBody {
   tags: ObjectTag[];
 }
+
+// ========== Notification Types ==========
+
+export interface NotificationParams extends BucketParams {
+  notificationId: string;
+}
+
+export interface NotificationEntry {
+  id?: string;
+  endpoint: string;
+  events: string[];
+  prefix?: string;
+  suffix?: string;
+}
+
+export interface NotificationConfigBody {
+  notifications: NotificationEntry[];
+}
+
+export interface TestEndpointBody {
+  endpoint: string;
+}

--- a/backend/src/utils/auditLog.ts
+++ b/backend/src/utils/auditLog.ts
@@ -57,6 +57,11 @@ export enum AuditEventType {
   LOCAL_LIST = 'local.list',
   LOCAL_MKDIR = 'local.mkdir',
 
+  // Notification operations
+  NOTIFICATION_CREATE = 'notification.create',
+  NOTIFICATION_DELETE = 'notification.delete',
+  NOTIFICATION_TEST = 'notification.test',
+
   // Generic operations (backward compatibility)
   GENERIC = 'generic',
 }

--- a/backend/src/utils/bucketWatcher.ts
+++ b/backend/src/utils/bucketWatcher.ts
@@ -1,0 +1,127 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLogger } from './logger';
+import { getAllBucketNames } from './notificationStore';
+import { dispatchWebhooks } from './webhookDispatcher';
+
+const logger = createLogger(undefined, '[BucketWatcher]');
+
+const BUCKET_DATA_PATH = process.env.BUCKET_DATA_PATH || '/var/lib/ceph/radosgw/buckets';
+
+const watchers = new Map<string, fs.FSWatcher>();
+const debounceTimers = new Map<string, NodeJS.Timeout>();
+
+const DEBOUNCE_MS = 200;
+
+function handleFileEvent(bucketName: string, eventType: string, filename: string | null): void {
+  if (!filename) return;
+
+  // Skip dotfiles (temp files, NFS artifacts, etc.)
+  if (filename.startsWith('.')) return;
+
+  const debounceKey = `${bucketName}/${filename}`;
+
+  const existing = debounceTimers.get(debounceKey);
+  if (existing) {
+    clearTimeout(existing);
+  }
+
+  debounceTimers.set(
+    debounceKey,
+    setTimeout(() => {
+      debounceTimers.delete(debounceKey);
+      processEvent(bucketName, eventType, filename);
+    }, DEBOUNCE_MS),
+  );
+}
+
+function processEvent(bucketName: string, eventType: string, filename: string): void {
+  // Decode %2F-encoded filenames back to S3 object keys
+  const objectKey = decodeURIComponent(filename);
+
+  if (eventType === 'rename') {
+    // rename = file created or deleted; check existence
+    const filePath = path.join(BUCKET_DATA_PATH, bucketName, filename);
+    fs.stat(filePath, (err, stats) => {
+      if (err) {
+        // File doesn't exist → deleted
+        void dispatchWebhooks(bucketName, 's3:ObjectRemoved:Delete', objectKey, 0);
+      } else {
+        // File exists → created
+        void dispatchWebhooks(bucketName, 's3:ObjectCreated:Put', objectKey, stats.size);
+      }
+    });
+  } else if (eventType === 'change') {
+    // File content modified
+    const filePath = path.join(BUCKET_DATA_PATH, bucketName, filename);
+    fs.stat(filePath, (err, stats) => {
+      const size = err ? 0 : stats.size;
+      void dispatchWebhooks(bucketName, 's3:ObjectCreated:Put', objectKey, size);
+    });
+  }
+}
+
+export function startWatching(bucketName: string): void {
+  if (watchers.has(bucketName)) {
+    return; // Already watching
+  }
+
+  const bucketDir = path.join(BUCKET_DATA_PATH, bucketName);
+
+  try {
+    fs.accessSync(bucketDir);
+  } catch {
+    logger.warn({ bucketName, path: bucketDir }, 'Bucket directory does not exist, skipping watcher');
+    return;
+  }
+
+  try {
+    const watcher = fs.watch(bucketDir, (eventType, filename) => {
+      handleFileEvent(bucketName, eventType, filename);
+    });
+
+    watcher.on('error', (err) => {
+      logger.error({ bucketName, error: err.message }, 'Watcher error');
+      stopWatching(bucketName);
+    });
+
+    watchers.set(bucketName, watcher);
+    logger.info({ bucketName }, 'Started watching bucket directory');
+  } catch (err) {
+    logger.warn({ bucketName, error: (err as Error).message }, 'Failed to start watcher');
+  }
+}
+
+export function stopWatching(bucketName: string): void {
+  const watcher = watchers.get(bucketName);
+  if (watcher) {
+    watcher.close();
+    watchers.delete(bucketName);
+    logger.info({ bucketName }, 'Stopped watching bucket directory');
+  }
+
+  // Clean up any pending debounce timers for this bucket
+  for (const [key, timer] of debounceTimers.entries()) {
+    if (key.startsWith(`${bucketName}/`)) {
+      clearTimeout(timer);
+      debounceTimers.delete(key);
+    }
+  }
+}
+
+export async function initializeWatchers(): Promise<void> {
+  const bucketNames = await getAllBucketNames();
+  logger.info({ count: bucketNames.length }, 'Initializing bucket watchers');
+
+  for (const bucketName of bucketNames) {
+    startWatching(bucketName);
+  }
+}
+
+export function shutdownWatchers(): void {
+  logger.info({ count: watchers.size }, 'Shutting down all bucket watchers');
+
+  for (const bucketName of watchers.keys()) {
+    stopWatching(bucketName);
+  }
+}

--- a/backend/src/utils/notificationStore.ts
+++ b/backend/src/utils/notificationStore.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { NotificationEntry } from '../types';
+import { createLogger } from './logger';
+
+const logger = createLogger(undefined, '[NotificationStore]');
+
+const STORE_PATH = process.env.NOTIFICATION_STORE_PATH || '/var/lib/ceph/radosgw/db/notifications.json';
+
+interface NotificationStoreData {
+  buckets: Record<string, NotificationEntry[]>;
+}
+
+let cache: NotificationStoreData | null = null;
+
+// Promise-based mutex to serialize write operations
+let writeLock: Promise<void> = Promise.resolve();
+
+async function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  let release: () => void;
+  const nextLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const prevLock = writeLock;
+  writeLock = nextLock;
+
+  await prevLock;
+  try {
+    return await fn();
+  } finally {
+    release!();
+  }
+}
+
+async function readStore(): Promise<NotificationStoreData> {
+  if (cache) {
+    return cache;
+  }
+
+  try {
+    const data = await fs.readFile(STORE_PATH, 'utf-8');
+    cache = JSON.parse(data) as NotificationStoreData;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      cache = { buckets: {} };
+    } else {
+      logger.error(err, 'Failed to read notification store');
+      cache = { buckets: {} };
+    }
+  }
+
+  return cache!;
+}
+
+async function writeStore(data: NotificationStoreData): Promise<void> {
+  cache = data;
+
+  try {
+    const dir = path.dirname(STORE_PATH);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(STORE_PATH, JSON.stringify(data, null, 2), 'utf-8');
+  } catch (err) {
+    logger.error(err, 'Failed to write notification store');
+  }
+}
+
+export async function getNotifications(bucketName: string): Promise<NotificationEntry[]> {
+  const store = await readStore();
+  return store.buckets[bucketName] || [];
+}
+
+export async function setNotifications(bucketName: string, notifications: NotificationEntry[]): Promise<void> {
+  await withLock(async () => {
+    const store = await readStore();
+
+    if (notifications.length === 0) {
+      delete store.buckets[bucketName];
+    } else {
+      store.buckets[bucketName] = notifications;
+    }
+
+    await writeStore(store);
+  });
+}
+
+/**
+ * Delete a notification by ID. Returns true if the notification was found and removed.
+ */
+export async function deleteNotification(bucketName: string, notificationId: string): Promise<boolean> {
+  return withLock(async () => {
+    const store = await readStore();
+    const current = store.buckets[bucketName] || [];
+    const remaining = current.filter((n) => n.id !== notificationId);
+
+    if (remaining.length === current.length) {
+      return false; // Nothing was deleted
+    }
+
+    if (remaining.length === 0) {
+      delete store.buckets[bucketName];
+    } else {
+      store.buckets[bucketName] = remaining;
+    }
+
+    await writeStore(store);
+    return true;
+  });
+}
+
+export async function getAllBucketNames(): Promise<string[]> {
+  const store = await readStore();
+  return Object.keys(store.buckets);
+}

--- a/backend/src/utils/webhookDispatcher.ts
+++ b/backend/src/utils/webhookDispatcher.ts
@@ -1,0 +1,76 @@
+import axios from 'axios';
+import { createLogger } from './logger';
+import { getNotifications } from './notificationStore';
+import { NotificationEntry } from '../types';
+
+const logger = createLogger(undefined, '[WebhookDispatcher]');
+
+function matchesEvent(notification: NotificationEntry, eventName: string): boolean {
+  return notification.events.some((pattern) => {
+    if (pattern === eventName) return true;
+    // Wildcard matching: "s3:ObjectCreated:*" matches "s3:ObjectCreated:Put"
+    if (pattern.endsWith(':*')) {
+      const prefix = pattern.slice(0, -1); // "s3:ObjectCreated:"
+      return eventName.startsWith(prefix) || eventName === pattern;
+    }
+    return false;
+  });
+}
+
+function matchesFilters(notification: NotificationEntry, objectKey: string): boolean {
+  if (notification.prefix && !objectKey.startsWith(notification.prefix)) {
+    return false;
+  }
+  if (notification.suffix && !objectKey.endsWith(notification.suffix)) {
+    return false;
+  }
+  return true;
+}
+
+export async function dispatchWebhooks(
+  bucketName: string,
+  eventName: string,
+  objectKey: string,
+  objectSize: number,
+): Promise<void> {
+  const notifications = await getNotifications(bucketName);
+
+  for (const notification of notifications) {
+    if (!matchesEvent(notification, eventName)) continue;
+    if (!matchesFilters(notification, objectKey)) continue;
+
+    const payload = {
+      Records: [
+        {
+          eventVersion: '2.1',
+          eventSource: 'aws:s3',
+          eventName,
+          eventTime: new Date().toISOString(),
+          s3: {
+            bucket: { name: bucketName },
+            object: { key: objectKey, size: objectSize },
+          },
+        },
+      ],
+    };
+
+    // Fire-and-forget
+    axios
+      .post(notification.endpoint, payload, {
+        timeout: 5000,
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .then(() => {
+        logger.info(
+          { bucket: bucketName, event: eventName, key: objectKey, endpoint: notification.endpoint },
+          'Webhook dispatched',
+        );
+      })
+      .catch((err) => {
+        logger.warn(
+          { bucket: bucketName, event: eventName, key: objectKey, endpoint: notification.endpoint, error: err.message },
+          'Webhook dispatch failed',
+        );
+      });
+  }
+}

--- a/charts/s4/Chart.yaml
+++ b/charts/s4/Chart.yaml
@@ -3,7 +3,7 @@ name: s4
 description: S4 (Super Simple Storage Service) - A lightweight S3-compatible storage solution
 type: application
 version: 0.1.0
-appVersion: "0.2.2"
+appVersion: "0.3.0"
 keywords:
   - s3
   - storage

--- a/charts/s4/README.md
+++ b/charts/s4/README.md
@@ -109,13 +109,13 @@ The following table lists the configurable parameters and their default values.
 
 ### Ingress Configuration (Web UI)
 
-| Parameter             | Description                          | Default |
-| --------------------- | ------------------------------------ | ------- |
+| Parameter             | Description                           | Default |
+| --------------------- | ------------------------------------- | ------- |
 | `ingress.enabled`     | Enable ingress for Web UI (port 5000) | `false` |
-| `ingress.className`   | Ingress class name                   | `""`    |
-| `ingress.annotations` | Ingress annotations                  | `{}`    |
-| `ingress.hosts`       | Ingress hosts configuration          | `[]`    |
-| `ingress.tls`         | Ingress TLS configuration            | `[]`    |
+| `ingress.className`   | Ingress class name                    | `""`    |
+| `ingress.annotations` | Ingress annotations                   | `{}`    |
+| `ingress.hosts`       | Ingress hosts configuration           | `[]`    |
+| `ingress.tls`         | Ingress TLS configuration             | `[]`    |
 
 ### Ingress Configuration (S3 API)
 
@@ -123,24 +123,24 @@ Optionally expose the S3 API (port 7480) externally via a separate Ingress.
 
 > **Warning:** Enabling this exposes the S3 API outside the cluster. Ensure proper authentication and network policies are in place.
 
-| Parameter                  | Description                           | Default |
-| -------------------------- | ------------------------------------- | ------- |
-| `ingress.s3Api.enabled`    | Enable ingress for S3 API (port 7480) | `false` |
-| `ingress.s3Api.className`  | Ingress class name                    | `""`    |
-| `ingress.s3Api.annotations`| Ingress annotations                   | `{}`    |
-| `ingress.s3Api.hosts`      | Ingress hosts configuration           | `[]`    |
-| `ingress.s3Api.tls`        | Ingress TLS configuration             | `[]`    |
+| Parameter                   | Description                           | Default |
+| --------------------------- | ------------------------------------- | ------- |
+| `ingress.s3Api.enabled`     | Enable ingress for S3 API (port 7480) | `false` |
+| `ingress.s3Api.className`   | Ingress class name                    | `""`    |
+| `ingress.s3Api.annotations` | Ingress annotations                   | `{}`    |
+| `ingress.s3Api.hosts`       | Ingress hosts configuration           | `[]`    |
+| `ingress.s3Api.tls`         | Ingress TLS configuration             | `[]`    |
 
 ### OpenShift Route Configuration (Web UI)
 
-| Parameter                                 | Description                             | Default    |
-| ----------------------------------------- | --------------------------------------- | ---------- |
+| Parameter                                 | Description                                   | Default    |
+| ----------------------------------------- | --------------------------------------------- | ---------- |
 | `route.enabled`                           | Enable OpenShift Route for Web UI (port 5000) | `true`     |
-| `route.host`                              | Route hostname                          | `""`       |
-| `route.path`                              | Route path                              | `""`       |
-| `route.annotations`                       | Route annotations                       | `{}`       |
-| `route.tls.termination`                   | TLS termination type                    | `edge`     |
-| `route.tls.insecureEdgeTerminationPolicy` | Insecure edge policy                    | `Redirect` |
+| `route.host`                              | Route hostname                                | `""`       |
+| `route.path`                              | Route path                                    | `""`       |
+| `route.annotations`                       | Route annotations                             | `{}`       |
+| `route.tls.termination`                   | TLS termination type                          | `edge`     |
+| `route.tls.insecureEdgeTerminationPolicy` | Insecure edge policy                          | `Redirect` |
 
 ### OpenShift Route Configuration (S3 API)
 
@@ -148,14 +148,14 @@ Optionally expose the S3 API (port 7480) externally via a separate Route.
 
 > **Warning:** Enabling this exposes the S3 API outside the cluster. Ensure proper authentication and network policies are in place.
 
-| Parameter                                        | Description                              | Default    |
-| ------------------------------------------------ | ---------------------------------------- | ---------- |
-| `route.s3Api.enabled`                            | Enable OpenShift Route for S3 API (port 7480) | `false`    |
-| `route.s3Api.host`                               | Route hostname                           | `""`       |
-| `route.s3Api.path`                               | Route path                               | `""`       |
-| `route.s3Api.annotations`                        | Route annotations                        | `{}`       |
-| `route.s3Api.tls.termination`                    | TLS termination type                     | `edge`     |
-| `route.s3Api.tls.insecureEdgeTerminationPolicy`  | Insecure edge policy                     | `Redirect` |
+| Parameter                                       | Description                                   | Default    |
+| ----------------------------------------------- | --------------------------------------------- | ---------- |
+| `route.s3Api.enabled`                           | Enable OpenShift Route for S3 API (port 7480) | `false`    |
+| `route.s3Api.host`                              | Route hostname                                | `""`       |
+| `route.s3Api.path`                              | Route path                                    | `""`       |
+| `route.s3Api.annotations`                       | Route annotations                             | `{}`       |
+| `route.s3Api.tls.termination`                   | TLS termination type                          | `edge`     |
+| `route.s3Api.tls.insecureEdgeTerminationPolicy` | Insecure edge policy                          | `Redirect` |
 
 ### Security Configuration
 
@@ -296,9 +296,9 @@ helm upgrade s4 ./charts/s4 --namespace s4 --reuse-values
 
 S4 exposes two endpoints:
 
-| Endpoint | Port | Purpose |
-| -------- | ---- | ------- |
-| **Web UI** | 5000 | Browser-based storage management interface |
+| Endpoint   | Port | Purpose                                                    |
+| ---------- | ---- | ---------------------------------------------------------- |
+| **Web UI** | 5000 | Browser-based storage management interface                 |
 | **S3 API** | 7480 | S3-compatible API for `aws s3`, `mc`, and other S3 clients |
 
 ### Port Forward (Development)

--- a/docker/config
+++ b/docker/config
@@ -9,5 +9,6 @@ rgw_posix_tmp_path = /var/lib/ceph/radosgw/tmp
 
 admin socket = /var/lib/ceph/radosgw/ceph-$cluster-$name.asok
 
+rgw_enable_apis = s3, s3website, sts, sns, notifications
 rgw_enable_usage_log = false
 rgw_enable_ops_log = false

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Complete REST API documentation with examples.
 - **[API Overview](api/README.md)** - Authentication and common patterns
 - **[Buckets API](api/buckets.md)** - S3 bucket operations
 - **[Objects API](api/objects.md)** - S3 object operations
+- **[Notifications API](api/notifications.md)** - Bucket notification webhooks
 - **[Transfer API](api/transfer.md)** - Cross-storage file transfers
 - **[Settings API](api/settings.md)** - Configuration management
 - **[Local Storage API](api/local.md)** - Local filesystem operations

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -313,6 +313,14 @@ Rate limits are hardcoded and stored in-memory. Exceeded limits return HTTP 429 
   - `POST /objects/huggingface-import` - Import HuggingFace model
   - `GET /objects/upload-progress/:encodedKey` - Upload progress (SSE)
 
+### Notifications
+
+- [Notifications API](notifications.md)
+  - `GET /notifications/:bucketName` - Get bucket notification configurations
+  - `PUT /notifications/:bucketName` - Set bucket notification configurations
+  - `DELETE /notifications/:bucketName/:notificationId` - Remove a notification
+  - `POST /notifications/test-endpoint` - Test a webhook endpoint
+
 ### Transfers
 
 - [Transfer API](transfer.md)

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -144,6 +144,56 @@ curl -X POST http://localhost:5000/api/objects/huggingface-import \
   }'
 ```
 
+## Notification Webhook Configuration
+
+```bash
+#!/bin/bash
+TOKEN="your-jwt-token"
+BUCKET="my-bucket"
+
+# 1. Test endpoint reachability
+curl -X POST http://localhost:5000/api/notifications/test-endpoint \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"endpoint": "https://example.com/webhook"}'
+
+# 2. Configure notifications
+curl -X PUT "http://localhost:5000/api/notifications/$BUCKET" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "notifications": [
+      {
+        "endpoint": "https://example.com/webhook",
+        "events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+        "prefix": "data/",
+        "suffix": ".csv"
+      }
+    ]
+  }'
+
+# 3. View current configuration
+curl "http://localhost:5000/api/notifications/$BUCKET" \
+  -H "Authorization: Bearer $TOKEN"
+
+# 4. Add a second notification without removing existing ones
+CURRENT=$(curl -s "http://localhost:5000/api/notifications/$BUCKET" \
+  -H "Authorization: Bearer $TOKEN")
+echo "$CURRENT" | jq '.notifications += [{
+  "endpoint": "https://example.com/audit",
+  "events": ["s3:ObjectRemoved:*"]
+}]' | curl -X PUT "http://localhost:5000/api/notifications/$BUCKET" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @-
+
+# 5. Delete a specific notification by ID
+NOTIF_ID=$(curl -s "http://localhost:5000/api/notifications/$BUCKET" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.notifications[0].id')
+curl -X DELETE "http://localhost:5000/api/notifications/$BUCKET/$NOTIF_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
 ## Batch Operations
 
 ```bash

--- a/docs/api/notifications.md
+++ b/docs/api/notifications.md
@@ -1,0 +1,404 @@
+# Notifications API
+
+S4 supports webhook-based bucket notifications. When objects are created, modified, or deleted in a bucket, S4 sends HTTP POST requests to configured webhook endpoints with S3-compatible event payloads.
+
+## How It Works
+
+1. **Configuration** - You configure one or more webhook endpoints per bucket, specifying which event types to listen for and optional key filters
+2. **Filesystem watching** - S4 watches the bucket's data directory on disk using `fs.watch()`
+3. **Debounce** - Rapid changes to the same file are debounced (200ms) to prevent duplicate events
+4. **Dispatch** - When a matching event occurs, S4 sends a fire-and-forget HTTP POST to each matching webhook endpoint with a 5-second timeout
+
+## Endpoints
+
+### Get Bucket Notifications
+
+Retrieve the current notification configurations for a bucket.
+
+```
+GET /api/notifications/:bucketName
+```
+
+**Parameters**:
+
+| Parameter    | Location | Description         |
+| ------------ | -------- | ------------------- |
+| `bucketName` | path     | Name of the bucket  |
+
+**Response** (`200 OK`):
+
+```json
+{
+  "notifications": [
+    {
+      "id": "notif-1708345845123-482910",
+      "endpoint": "https://example.com/webhook",
+      "events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+      "prefix": "data/",
+      "suffix": ".csv"
+    }
+  ]
+}
+```
+
+If no notifications are configured, returns an empty array:
+
+```json
+{
+  "notifications": []
+}
+```
+
+**Example**:
+
+```bash
+curl http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+### Set Bucket Notifications
+
+Create or replace the notification configurations for a bucket. This replaces all existing notifications for the bucket with the provided list.
+
+```
+PUT /api/notifications/:bucketName
+```
+
+**Parameters**:
+
+| Parameter    | Location | Description         |
+| ------------ | -------- | ------------------- |
+| `bucketName` | path     | Name of the bucket  |
+
+**Request Body**:
+
+```json
+{
+  "notifications": [
+    {
+      "endpoint": "https://example.com/webhook",
+      "events": ["s3:ObjectCreated:*"],
+      "prefix": "uploads/",
+      "suffix": ".json"
+    }
+  ]
+}
+```
+
+**Notification Object Fields**:
+
+| Field      | Type     | Required | Description                                                    |
+| ---------- | -------- | -------- | -------------------------------------------------------------- |
+| `id`       | string   | No       | Notification ID. Auto-generated if not provided.               |
+| `endpoint` | string   | Yes      | HTTP or HTTPS URL to receive webhook POST requests.            |
+| `events`   | string[] | Yes      | Event types to listen for. At least one required.              |
+| `prefix`   | string   | No       | Only trigger for object keys starting with this string.        |
+| `suffix`   | string   | No       | Only trigger for object keys ending with this string.          |
+
+**Validation Rules**:
+
+- `endpoint` must match `^https?://.+` (HTTP or HTTPS URL)
+- `events` must contain at least one entry
+- Valid event values: `s3:ObjectCreated:*`, `s3:ObjectRemoved:*`
+
+**Response** (`200 OK`):
+
+```json
+{
+  "message": "Notification configuration updated successfully"
+}
+```
+
+**Example**:
+
+```bash
+curl -X PUT http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "notifications": [
+      {
+        "endpoint": "https://example.com/webhook",
+        "events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+      }
+    ]
+  }'
+```
+
+**Behavior Notes**:
+
+- Entries without an `id` field are automatically assigned one (format: `notif-<timestamp>-<random>`)
+- The bucket's filesystem watcher is started automatically when notifications are set
+- This is a **replace** operation: the entire list of notifications is replaced. To add a notification without removing existing ones, first GET the current list, append your entry, then PUT the combined list.
+
+---
+
+### Delete Notification
+
+Remove a single notification configuration from a bucket.
+
+```
+DELETE /api/notifications/:bucketName/:notificationId
+```
+
+**Parameters**:
+
+| Parameter        | Location | Description                        |
+| ---------------- | -------- | ---------------------------------- |
+| `bucketName`     | path     | Name of the bucket                 |
+| `notificationId` | path    | ID of the notification to remove   |
+
+**Response** (`200 OK`):
+
+```json
+{
+  "message": "Notification removed successfully"
+}
+```
+
+**Example**:
+
+```bash
+curl -X DELETE http://localhost:5000/api/notifications/my-bucket/notif-1708345845123-482910 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Behavior Notes**:
+
+- If the deleted notification was the last one for the bucket, the filesystem watcher is stopped automatically
+- Deleting a non-existent notification ID completes without error
+
+---
+
+### Test Webhook Endpoint
+
+Send a sample S3 notification event to a URL to verify it is reachable and responsive.
+
+```
+POST /api/notifications/test-endpoint
+```
+
+**Request Body**:
+
+```json
+{
+  "endpoint": "https://example.com/webhook"
+}
+```
+
+| Field      | Type   | Required | Description                             |
+| ---------- | ------ | -------- | --------------------------------------- |
+| `endpoint` | string | Yes      | HTTP or HTTPS URL to test               |
+
+**Validation**: `endpoint` must match `^https?://.+`
+
+**Success Response** (`200 OK`):
+
+```json
+{
+  "success": true,
+  "statusCode": 200,
+  "message": "Endpoint responded with status 200"
+}
+```
+
+**Failure Response** (`400 Bad Request`):
+
+```json
+{
+  "success": false,
+  "message": "Failed to reach endpoint: connect ECONNREFUSED 127.0.0.1:9999"
+}
+```
+
+**Test Event Payload**:
+
+The test sends this payload to the endpoint:
+
+```json
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "eventName": "s3:TestEvent",
+      "eventTime": "2024-02-19T10:30:45.123Z",
+      "s3": {
+        "bucket": { "name": "test-bucket" },
+        "object": { "key": "test-object.txt", "size": 0 }
+      }
+    }
+  ]
+}
+```
+
+**Example**:
+
+```bash
+curl -X POST http://localhost:5000/api/notifications/test-endpoint \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"endpoint": "https://example.com/webhook"}'
+```
+
+**Behavior Notes**:
+
+- The test accepts any HTTP status code from the endpoint (it uses `validateStatus: () => true`)
+- A successful test means the endpoint is reachable; the `statusCode` field tells you what the endpoint returned
+- The test uses the same 5-second timeout as production webhooks
+
+---
+
+## Webhook Payload Format
+
+All webhook payloads follow the AWS S3 notification event format:
+
+```json
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "eventName": "s3:ObjectCreated:Put",
+      "eventTime": "2024-02-19T10:30:45.123Z",
+      "s3": {
+        "bucket": { "name": "my-bucket" },
+        "object": { "key": "path/to/file.txt", "size": 1024 }
+      }
+    }
+  ]
+}
+```
+
+### Event Types
+
+| Event Name                | Trigger                                       |
+| ------------------------- | --------------------------------------------- |
+| `s3:ObjectCreated:Put`    | Object was created or overwritten             |
+| `s3:ObjectRemoved:Delete` | Object was deleted                            |
+| `s3:TestEvent`            | Sent by the Test Endpoint feature             |
+
+### Wildcard Patterns
+
+| Pattern                | Matches                                        |
+| ---------------------- | ---------------------------------------------- |
+| `s3:ObjectCreated:*`   | `s3:ObjectCreated:Put` and all created events  |
+| `s3:ObjectRemoved:*`   | `s3:ObjectRemoved:Delete` and all removed events |
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable                  | Default                                          | Description                                      |
+| ------------------------- | ------------------------------------------------ | ------------------------------------------------ |
+| `NOTIFICATION_STORE_PATH` | `/var/lib/ceph/radosgw/db/notifications.json`    | Path to the JSON file storing notification configs |
+| `BUCKET_DATA_PATH`        | `/var/lib/ceph/radosgw/buckets`                  | Path to the Ceph POSIX backend bucket data directory |
+
+### Storage Format
+
+Notification configurations are stored as a JSON file:
+
+```json
+{
+  "buckets": {
+    "my-bucket": [
+      {
+        "id": "notif-1708345845123-482910",
+        "endpoint": "https://example.com/webhook",
+        "events": ["s3:ObjectCreated:*"],
+        "prefix": "data/",
+        "suffix": ".csv"
+      }
+    ]
+  }
+}
+```
+
+The store uses an in-memory cache for performance. Changes are written to disk immediately.
+
+---
+
+## Technical Details
+
+- **Debounce**: Filesystem events for the same file are debounced with a 200ms delay to handle rapid changes (e.g., editors that write-delete-rename)
+- **Timeout**: Webhook HTTP requests have a 5-second timeout
+- **Fire-and-forget**: Webhook dispatch is asynchronous. S4 does not wait for webhook responses and does not retry failed deliveries
+- **Dotfile filtering**: Changes to files starting with `.` (hidden files, editor temp files, NFS artifacts) are ignored
+- **Filename decoding**: Ceph POSIX backend encodes `/` in object keys as `%2F` in filenames. S4 decodes these back to the original object key before dispatching
+- **Auto-initialization**: On startup, S4 automatically starts filesystem watchers for all buckets that have existing notification configurations
+- **Cleanup**: When all notifications for a bucket are deleted, the filesystem watcher for that bucket is stopped. Pending debounce timers are also cleaned up
+
+---
+
+## Common Use Cases
+
+### Monitor All Changes in a Bucket
+
+```bash
+curl -X PUT http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "notifications": [
+      {
+        "endpoint": "https://example.com/webhook",
+        "events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+      }
+    ]
+  }'
+```
+
+### Filter by Prefix and Suffix
+
+Only trigger for CSV files uploaded to the `data/` path:
+
+```bash
+curl -X PUT http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "notifications": [
+      {
+        "endpoint": "https://example.com/csv-processor",
+        "events": ["s3:ObjectCreated:*"],
+        "prefix": "data/",
+        "suffix": ".csv"
+      }
+    ]
+  }'
+```
+
+### Add a Notification Without Replacing Existing Ones
+
+Since PUT replaces the entire list, you need to fetch existing notifications first:
+
+```bash
+# 1. Get current notifications
+CURRENT=$(curl -s http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN")
+
+# 2. Add new entry and PUT the combined list
+echo "$CURRENT" | jq '.notifications += [{
+  "endpoint": "https://example.com/new-hook",
+  "events": ["s3:ObjectRemoved:*"]
+}]' | curl -X PUT http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @-
+```
+
+### Delete a Specific Notification
+
+```bash
+# 1. Find the notification ID
+curl -s http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN" | jq '.notifications[].id'
+
+# 2. Delete by ID
+curl -X DELETE http://localhost:5000/api/notifications/my-bucket/notif-1708345845123-482910 \
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -34,6 +34,7 @@ S4 is a lightweight, self-contained S3-compatible storage solution with a web-ba
 
 - Web-based file browser for S3 buckets and local storage
 - Bucket management (create, delete, browse)
+- Bucket notification management (webhook configuration)
 - Object operations (upload, download, delete)
 - Cross-storage file transfers
 - HuggingFace model import
@@ -58,6 +59,7 @@ See [Frontend Architecture](frontend.md) for details.
 - RESTful API for storage operations
 - Serves static frontend files in production
 - S3 SDK integration (AWS SDK v3)
+- Filesystem-based bucket notification watching with webhook dispatch
 - JWT-based authentication (optional)
 - SSE endpoints for real-time progress
 - Request validation and error handling
@@ -162,6 +164,7 @@ s4/
 │       │   ├── auth/      # Authentication endpoints
 │       │   ├── buckets/   # Bucket operations
 │       │   ├── objects/   # Object operations
+│       │   ├── notifications/ # Bucket notification management
 │       │   ├── transfer/  # Transfer operations
 │       │   ├── settings/  # Configuration management
 │       │   └── local/     # Local filesystem operations
@@ -176,6 +179,7 @@ s4/
 │       │   ├── AppLayout.tsx          # Main layout
 │       │   ├── StorageBrowser.tsx     # File browser
 │       │   ├── Buckets.tsx            # Bucket management
+│       │   ├── BucketNotificationsModal.tsx # Notification config
 │       │   ├── Settings.tsx           # Configuration UI
 │       │   └── AuthContext.tsx        # Auth state management
 │       ├── hooks/         # Custom React hooks
@@ -207,6 +211,7 @@ s4/
 - **Framework**: Fastify 4
 - **Language**: TypeScript
 - **S3 Client**: AWS SDK v3
+- **Notifications**: Filesystem watching with webhook dispatch
 - **Authentication**: JWT (jsonwebtoken)
 - **Validation**: Fastify JSON Schema
 - **Logging**: Pino (Fastify's logger)

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -8,6 +8,7 @@ The S4 backend is a TypeScript-based Fastify application that provides a RESTful
 - **Runtime**: Node.js 18+
 - **Language**: TypeScript
 - **S3 Client**: AWS SDK v3
+- **Notifications**: Filesystem watching with webhook dispatch
 - **Authentication**: JWT (jsonwebtoken)
 - **Validation**: Fastify JSON Schema
 - **Logging**: Pino (Fastify's built-in logger)
@@ -141,6 +142,7 @@ backend/
 │   │   ├── auth/             # Authentication (info, login, logout, me, sse-ticket)
 │   │   ├── buckets/          # Bucket operations (list, create, delete)
 │   │   ├── objects/          # Object operations (upload, download, list, delete, view)
+│   │   ├── notifications/    # Bucket notification management (webhooks)
 │   │   ├── transfer/         # Transfer operations (create, progress, cancel, cleanup)
 │   │   ├── settings/         # Configuration (S3, HuggingFace, proxy, limits)
 │   │   ├── local/            # Local storage operations
@@ -159,6 +161,9 @@ backend/
 │   │   ├── httpStatus.ts     # HTTP status constants
 │   │   ├── transferQueue.ts  # Transfer job management
 │   │   ├── sseTickets.ts     # SSE ticket generation
+│   │   ├── notificationStore.ts # Notification config persistence
+│   │   ├── bucketWatcher.ts    # Filesystem watcher for bucket events
+│   │   ├── webhookDispatcher.ts # Webhook dispatch for notifications
 │   │   └── ...               # Other utilities
 │   │
 │   ├── types.ts              # TypeScript type definitions
@@ -198,6 +203,13 @@ Routes are organized under `/api/*` and auto-loaded from `src/routes/api/`:
 - `DELETE /:bucketName/:encodedKey` - Delete object or folder
 - `GET /view/:bucketName/:encodedKey` - View object metadata and content preview
 - `POST /huggingface-import` - Import model from HuggingFace
+
+### Notification Routes (`/api/notifications`)
+
+- `GET /:bucketName` - Get notification configurations for a bucket
+- `PUT /:bucketName` - Set notification configurations (starts filesystem watcher)
+- `DELETE /:bucketName/:notificationId` - Remove a single notification (stops watcher if none remain)
+- `POST /test-endpoint` - Test an HTTP endpoint by sending a sample S3 event
 
 ### Transfer Routes (`/api/transfer`)
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -48,6 +48,8 @@ AWS_S3_ENDPOINT=https://rgw.example.com
 | `JWT_SECRET`             | (auto-generated) | No       | JWT signing secret (auto-generated if not provided)                    |
 | `JWT_EXPIRATION_HOURS`   | `8`              | No       | JWT token expiration time in hours                                     |
 | `SSE_TICKET_TTL_SECONDS` | `60`             | No       | Server-Sent Events one-time ticket TTL in seconds                      |
+| `NOTIFICATION_STORE_PATH`| `/var/lib/ceph/radosgw/db/notifications.json` | No | Path to JSON file storing notification configs |
+| `BUCKET_DATA_PATH`       | `/var/lib/ceph/radosgw/buckets` | No | Path to Ceph POSIX backend bucket data directory |
 
 #### Authentication Modes
 
@@ -430,11 +432,11 @@ storage:
   maxFileSizeGB: 20
   maxConcurrentTransfers: 2
   data:
-    size: 10Gi          # S3 data PVC (required)
+    size: 10Gi # S3 data PVC (required)
     storageClass: ''
     existingClaim: ''
   localStorage:
-    size: 50Gi          # Local storage PVC (only created when localPaths is set)
+    size: 50Gi # Local storage PVC (only created when localPaths is set)
     storageClass: ''
     existingClaim: ''
 ```

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -222,18 +222,18 @@ See the [Helm chart README](../../charts/s4/README.md) for complete values docum
 
 Key configuration groups:
 
-| Group         | Description                   |
-| ------------- | ----------------------------- |
-| `image.*`     | Container image settings      |
-| `s3.*`        | S3 backend configuration      |
-| `auth.*`      | Authentication settings       |
-| `storage.*`   | PVC sizes and storage classes |
-| `resources.*` | CPU and memory limits         |
-| `service.*`   | Service type and ports        |
-| `ingress.*`   | Web UI Ingress configuration         |
-| `ingress.s3Api.*` | S3 API Ingress configuration (optional) |
-| `route.*`     | Web UI OpenShift Route configuration |
-| `route.s3Api.*` | S3 API OpenShift Route configuration (optional) |
+| Group             | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| `image.*`         | Container image settings                        |
+| `s3.*`            | S3 backend configuration                        |
+| `auth.*`          | Authentication settings                         |
+| `storage.*`       | PVC sizes and storage classes                   |
+| `resources.*`     | CPU and memory limits                           |
+| `service.*`       | Service type and ports                          |
+| `ingress.*`       | Web UI Ingress configuration                    |
+| `ingress.s3Api.*` | S3 API Ingress configuration (optional)         |
+| `route.*`         | Web UI OpenShift Route configuration            |
+| `route.s3Api.*`   | S3 API OpenShift Route configuration (optional) |
 
 ### Upgrading with Helm
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -19,6 +19,7 @@ Perfect for POCs, development environments, demos, and simple deployments where 
 - ✅ Object operations (upload, download, delete, browse)
 - ✅ Local filesystem/PVC browsing
 - ✅ Cross-storage file transfers (S3 ↔ Local)
+- ✅ Bucket notifications via webhooks
 - ✅ HuggingFace model import
 - ✅ Single container deployment
 - ✅ Persistent storage with SQLite

--- a/docs/operations/faq.md
+++ b/docs/operations/faq.md
@@ -275,6 +275,47 @@ Then use the HuggingFace import feature in the UI.
 - **In transit**: Deploy behind HTTPS reverse proxy/ingress
 - **S3 SSE**: Not currently supported
 
+### Does S4 support bucket notifications?
+
+Yes. S4 supports webhook-based bucket notifications. You can configure one or more HTTP/HTTPS webhook endpoints per bucket, and S4 will send POST requests with S3-compatible event payloads when objects are created, modified, or deleted. Notifications can be configured via the web UI (notification bell icon on each bucket) or via the [Notifications API](../api/notifications.md).
+
+### What webhook payload format does S4 use?
+
+S4 sends a simplified AWS S3 notification format:
+
+```json
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "eventName": "s3:ObjectCreated:Put",
+      "eventTime": "2024-02-19T10:30:45.123Z",
+      "s3": {
+        "bucket": { "name": "my-bucket" },
+        "object": { "key": "path/to/file.txt", "size": 1024 }
+      }
+    }
+  ]
+}
+```
+
+This is a subset of the full AWS S3 notification format, containing the most commonly used fields.
+
+### Are notification webhooks retried if they fail?
+
+No. S4 uses fire-and-forget delivery with a 5-second timeout. If a webhook endpoint is unreachable or returns an error, the notification is not retried. Failed deliveries are logged as warnings in S4's server logs.
+
+### Can I filter which events trigger notifications?
+
+Yes. Each notification configuration supports two types of filters:
+
+- **Event type selection** - Choose `s3:ObjectCreated:*` (object created/modified), `s3:ObjectRemoved:*` (object deleted), or both
+- **Prefix filter** - Only trigger for object keys starting with a specified string (e.g., `uploads/`)
+- **Suffix filter** - Only trigger for object keys ending with a specified string (e.g., `.json`)
+
+When both prefix and suffix filters are set, an object must match both to trigger the notification.
+
 ## Troubleshooting Questions
 
 ### S4 container won't start

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -405,6 +405,104 @@ kubectl edit pvc s4-data
 # Increase: spec.resources.requests.storage
 ```
 
+## Notification / Webhook Issues
+
+### Webhooks Not Firing
+
+**Symptoms**:
+
+- Webhook endpoint not receiving any requests
+- No notification-related entries in logs
+
+**Diagnosis**:
+
+```bash
+# Check notification configuration exists
+curl http://localhost:5000/api/notifications/my-bucket \
+  -H "Authorization: Bearer $TOKEN"
+
+# Test endpoint reachability from S4
+curl -X POST http://localhost:5000/api/notifications/test-endpoint \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"endpoint": "https://example.com/webhook"}'
+
+# Check S4 logs for webhook dispatch errors
+kubectl logs <s4-pod> | grep -i webhook
+kubectl logs <s4-pod> | grep -i notification
+
+# Verify bucket directory exists on disk
+kubectl exec <s4-pod> -- ls -la /var/lib/ceph/radosgw/buckets/my-bucket
+```
+
+**Common Causes**:
+
+1. **Bucket directory does not exist** - The filesystem watcher requires the bucket data directory to exist at `BUCKET_DATA_PATH/<bucketName>`. If the bucket was created on an external S3 or the path is misconfigured, the watcher cannot start.
+
+2. **Endpoint unreachable from S4** - The webhook URL must be reachable from the S4 container. Use the test endpoint feature to verify.
+
+3. **Restrictive filters** - Prefix and suffix filters may be too narrow. Check that your object keys match the configured filters.
+
+4. **Debounce delay** - Events are debounced with a 200ms delay. Very rapid changes may be collapsed into a single event.
+
+5. **Dotfiles ignored** - Files starting with `.` (hidden files, editor temp files) are intentionally filtered out and do not trigger notifications.
+
+### Webhook Receiving Unexpected Events
+
+**Symptoms**:
+
+- Receiving more events than expected
+- Duplicate or unexpected event types
+
+**Solutions**:
+
+1. **Add filters** - Use prefix and suffix filters to narrow which objects trigger notifications
+
+2. **Editor temp files** - Some editors create temporary files during save operations (e.g., `file.txt~`, `file.txt.swp`). While dotfiles are filtered, non-dot temp files may trigger events. Use suffix filters to target specific file types.
+
+3. **Debounce** - A single save operation may generate multiple filesystem events (create + modify). The 200ms debounce handles most cases, but some edge cases may slip through.
+
+### Notifications Lost After Restart
+
+**Symptoms**:
+
+- Notification configurations disappear after S4 restarts
+- Webhooks stop firing after restart
+
+**Diagnosis**:
+
+```bash
+# Check if notification store file exists and has content
+kubectl exec <s4-pod> -- cat /var/lib/ceph/radosgw/db/notifications.json
+
+# Check file permissions
+kubectl exec <s4-pod> -- ls -la /var/lib/ceph/radosgw/db/notifications.json
+
+# Check if the storage path is on a persistent volume
+kubectl describe pod <s4-pod> | grep -A 5 "Mounts"
+```
+
+**Solutions**:
+
+1. **Mount persistent storage** - Ensure `/var/lib/ceph/radosgw/db/` is backed by a PersistentVolumeClaim. Without persistent storage, the notification configuration file is lost on restart.
+
+2. **Check file permissions** - The S4 process must have read/write access to the `NOTIFICATION_STORE_PATH` directory.
+
+### Test Endpoint Fails but Webhook Works (or Vice Versa)
+
+**Symptoms**:
+
+- Test endpoint returns failure but actual webhooks are delivered successfully
+- Test endpoint succeeds but real events are not received
+
+**Solutions**:
+
+1. **Event type filtering** - The test endpoint sends `s3:TestEvent`, which is a special event type. Your webhook receiver may filter or handle it differently than production events like `s3:ObjectCreated:Put`.
+
+2. **Network intermittency** - The test and production webhooks use the same 5-second timeout. Network conditions may vary between test time and event time.
+
+3. **Endpoint routing** - Some webhook receivers route based on the `eventName` field. Ensure your receiver accepts both `s3:TestEvent` and the production event types you configured.
+
 ## Performance Issues
 
 ### High Memory Usage

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -472,9 +472,9 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: encrypted-storage
-provisioner: your-csi-driver       # Use your cluster's CSI driver
+provisioner: your-csi-driver # Use your cluster's CSI driver
 parameters:
-  encrypted: 'true'                # Provider-specific encryption parameter
+  encrypted: 'true' # Provider-specific encryption parameter
 ```
 
 > **Note**: The `provisioner` and `parameters` depend on your cluster's storage backend (e.g., AWS EBS, Azure Disk, GCP PD, Ceph, etc.). Consult your provider's documentation for the correct values.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -224,6 +224,99 @@ The storage management view shows:
 
 ---
 
+## Bucket Notifications
+
+S4 supports webhook-based bucket notifications. When objects are created, modified, or deleted in a bucket, S4 can send HTTP POST requests to configured webhook endpoints with S3-compatible event payloads.
+
+### Use Cases
+
+- **CI/CD triggers** - Automatically start builds or deployments when new artifacts are uploaded
+- **Monitoring** - Track object changes for audit or compliance purposes
+- **Data processing pipelines** - Trigger downstream processing when new data arrives
+
+### Setting Up Notifications via the UI
+
+1. Navigate to **Storage Management**
+2. Click the **notification bell icon** on the bucket you want to configure
+3. The **Bucket Notifications** modal opens
+4. Click **Add Notification** and fill in the form:
+
+| Field              | Description                                                                 |
+| ------------------ | --------------------------------------------------------------------------- |
+| **Endpoint URL**   | HTTP or HTTPS URL that will receive webhook POST requests                   |
+| **Event Types**    | Select which events trigger notifications (created, removed, or both)       |
+| **Prefix Filter**  | (Optional) Only trigger for object keys starting with this string           |
+| **Suffix Filter**  | (Optional) Only trigger for object keys ending with this string             |
+
+5. Click **Save** to apply the notification configuration
+
+### Testing a Webhook Endpoint
+
+Before saving, you can verify your endpoint is reachable:
+
+1. Enter the endpoint URL
+2. Click **Test Endpoint**
+3. S4 sends a sample `s3:TestEvent` to the URL
+4. A success or failure message is displayed with the HTTP status code
+
+### Webhook Payload Format
+
+When an event occurs, S4 sends a JSON payload matching the AWS S3 notification format:
+
+```json
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "eventName": "s3:ObjectCreated:Put",
+      "eventTime": "2024-02-19T10:30:45.123Z",
+      "s3": {
+        "bucket": { "name": "my-bucket" },
+        "object": { "key": "path/to/file.txt", "size": 1024 }
+      }
+    }
+  ]
+}
+```
+
+### Event Types
+
+| Event Pattern           | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `s3:ObjectCreated:*`    | Matches all object creation events                 |
+| `s3:ObjectCreated:Put`  | Object was created or overwritten                  |
+| `s3:ObjectRemoved:*`    | Matches all object removal events                  |
+| `s3:ObjectRemoved:Delete` | Object was deleted                               |
+| `s3:TestEvent`          | Sent when using the Test Endpoint feature          |
+
+### Prefix and Suffix Filtering
+
+Filters let you narrow which objects trigger notifications:
+
+- **Prefix**: `images/` - Only objects whose keys start with `images/`
+- **Suffix**: `.csv` - Only objects whose keys end with `.csv`
+- **Both**: Prefix `data/` and suffix `.json` - Only JSON files under the `data/` path
+
+When both filters are set, an object must match **both** to trigger a notification.
+
+### Managing Existing Notifications
+
+- **View**: Open the notification modal to see all configured notifications for a bucket
+- **Delete**: Click the delete icon next to a notification to remove it
+
+### Important Notes
+
+- **Fire-and-forget delivery** - Webhooks are dispatched asynchronously; S4 does not wait for a response before continuing
+- **5-second timeout** - If an endpoint does not respond within 5 seconds, the request is abandoned
+- **No retries** - Failed webhook deliveries are not retried
+- **200ms debounce** - Rapid filesystem changes are debounced to avoid duplicate notifications
+- **Persistence** - Notification configurations are stored in a JSON file and survive restarts
+- **Auto-cleanup** - When a bucket is deleted, its notification configurations are automatically removed
+- **Dotfiles ignored** - Changes to files starting with `.` (hidden files, editor temp files) do not trigger notifications
+
+---
+
 ## Settings
 
 The Settings page allows you to configure S4's connections and behavior.
@@ -446,6 +539,14 @@ When importing models:
 - Check for sufficient disk space at the destination
 - Review conflict resolution settings
 
+**Notification webhooks not firing**:
+
+- Verify the webhook endpoint URL is reachable from S4 using the **Test Endpoint** button
+- Check that the correct event types are selected (created, removed, or both)
+- Review prefix/suffix filters to ensure they match your object keys
+- Confirm the bucket directory exists on disk (notifications use filesystem watching)
+- Check S4 logs for webhook dispatch errors
+
 For more detailed troubleshooting, see the [Troubleshooting Guide](../operations/troubleshooting.md).
 
 ---
@@ -456,4 +557,5 @@ For more detailed troubleshooting, see the [Troubleshooting Guide](../operations
 - [Error Reference](../operations/error-reference.md) - Complete error message reference
 - [FAQ](../operations/faq.md) - Frequently asked questions
 - [Configuration Guide](../deployment/configuration.md) - Environment variable reference
+- [Notifications API](../api/notifications.md) - Notification webhook API reference
 - [API Reference](../api/README.md) - Backend API documentation

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -453,7 +453,7 @@ Main components in `src/app/components/`:
 - **Login** - Login form component
 - **ProtectedRoute** - HOC for protecting routes (requires authentication)
 - **StorageBrowser** - Unified storage browser for S3 and local storage with upload/download
-- **Buckets** - S3 bucket management
+- **Buckets** - S3 bucket management (includes BucketNotificationsModal for webhook configuration)
 - **Settings** - S3 connection configuration
 - **DocumentRenderer** - Markdown/document viewer
 - **ResponsiveTable** - Responsive table wrapper with mobile card view

--- a/frontend/src/app/components/Buckets/BucketNotificationsModal.tsx
+++ b/frontend/src/app/components/Buckets/BucketNotificationsModal.tsx
@@ -1,0 +1,423 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import apiClient from '@app/utils/apiClient';
+import { notifyApiError, notifySuccess } from '@app/utils/notifications';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Content,
+  ContentVariants,
+  EmptyState,
+  EmptyStateBody,
+  ExpandableSection,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  Skeleton,
+  TextInput,
+  Tooltip,
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { BellIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+
+interface NotificationEntry {
+  id?: string;
+  endpoint: string;
+  events: string[];
+  prefix?: string;
+  suffix?: string;
+}
+
+interface BucketNotificationsModalProps {
+  bucketName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const BucketNotificationsModal: React.FunctionComponent<BucketNotificationsModalProps> = ({
+  bucketName,
+  isOpen,
+  onClose,
+}) => {
+  const { t } = useTranslation(['buckets', 'translation']);
+
+  // Notification list state
+  const [notifications, setNotifications] = React.useState<NotificationEntry[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  // Add form state
+  const [endpoint, setEndpoint] = React.useState('');
+  const [objectCreated, setObjectCreated] = React.useState(true);
+  const [objectRemoved, setObjectRemoved] = React.useState(true);
+  const [prefix, setPrefix] = React.useState('');
+  const [suffix, setSuffix] = React.useState('');
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [isTesting, setIsTesting] = React.useState(false);
+  const [testResult, setTestResult] = React.useState<{ success: boolean; message: string } | null>(null);
+  const [isFormExpanded, setIsFormExpanded] = React.useState(false);
+  const [editingNotificationId, setEditingNotificationId] = React.useState<string | null>(null);
+  const isEditMode = editingNotificationId !== null;
+
+  const loadNotifications = React.useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await apiClient.get(`/notifications/${bucketName}`);
+      setNotifications(response.data.notifications || []);
+    } catch (error) {
+      notifyApiError(t('notifications.error.loadFailed'), error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [bucketName, t]);
+
+  // Load notifications when modal opens
+  React.useEffect(() => {
+    if (isOpen && bucketName) {
+      loadNotifications();
+    }
+  }, [isOpen, bucketName, loadNotifications]);
+
+  const resetForm = () => {
+    setEndpoint('');
+    setObjectCreated(true);
+    setObjectRemoved(true);
+    setPrefix('');
+    setSuffix('');
+    setTestResult(null);
+    setEditingNotificationId(null);
+  };
+
+  const handleClose = () => {
+    resetForm();
+    setIsFormExpanded(false);
+    onClose();
+  };
+
+  const validateForm = (): boolean => {
+    if (!endpoint.trim()) return false;
+    if (!/^https?:\/\/.+/.test(endpoint)) return false;
+    if (!objectCreated && !objectRemoved) return false;
+    return true;
+  };
+
+  const handleEditClick = (entry: NotificationEntry) => {
+    setEndpoint(entry.endpoint);
+    setObjectCreated(entry.events.includes('s3:ObjectCreated:*'));
+    setObjectRemoved(entry.events.includes('s3:ObjectRemoved:*'));
+    setPrefix(entry.prefix || '');
+    setSuffix(entry.suffix || '');
+    setTestResult(null);
+    setEditingNotificationId(entry.id || null);
+    setIsFormExpanded(true);
+  };
+
+  const handleCancelEdit = () => {
+    resetForm();
+    setIsFormExpanded(false);
+  };
+
+  const handleSaveNotification = async () => {
+    if (!validateForm()) return;
+
+    const events: string[] = [];
+    if (objectCreated) events.push('s3:ObjectCreated:*');
+    if (objectRemoved) events.push('s3:ObjectRemoved:*');
+
+    let updatedNotifications: NotificationEntry[];
+
+    if (isEditMode) {
+      updatedNotifications = notifications.map((n) =>
+        n.id === editingNotificationId
+          ? { ...n, endpoint, events, prefix: prefix || undefined, suffix: suffix || undefined }
+          : n,
+      );
+    } else {
+      const newEntry: NotificationEntry = {
+        endpoint,
+        events,
+        prefix: prefix || undefined,
+        suffix: suffix || undefined,
+      };
+      updatedNotifications = [...notifications, newEntry];
+    }
+
+    setIsSaving(true);
+    try {
+      await apiClient.put(`/notifications/${bucketName}`, {
+        notifications: updatedNotifications,
+      });
+      if (isEditMode) {
+        notifySuccess(t('notifications.success.updated'), t('notifications.success.updatedMessage'));
+      } else {
+        notifySuccess(t('notifications.success.created'), t('notifications.success.createdMessage'));
+      }
+      resetForm();
+      setIsFormExpanded(false);
+      await loadNotifications();
+    } catch (error) {
+      notifyApiError(t('notifications.error.saveFailed'), error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDeleteNotification = async (notificationId: string) => {
+    try {
+      await apiClient.delete(`/notifications/${bucketName}/${notificationId}`);
+      notifySuccess(t('notifications.success.deleted'), t('notifications.success.deletedMessage'));
+      if (editingNotificationId === notificationId) {
+        resetForm();
+        setIsFormExpanded(false);
+      }
+      await loadNotifications();
+    } catch (error) {
+      notifyApiError(t('notifications.error.deleteFailed'), error);
+    }
+  };
+
+  const handleTestEndpoint = async () => {
+    setIsTesting(true);
+    setTestResult(null);
+    try {
+      const response = await apiClient.post('/notifications/test-endpoint', {
+        endpoint,
+      });
+      setTestResult({
+        success: true,
+        message: t('notifications.success.testSuccessMessage', {
+          statusCode: response.data.statusCode,
+        }),
+      });
+    } catch (error: unknown) {
+      const errMsg =
+        error && typeof error === 'object' && 'response' in error
+          ? (error as { response?: { data?: { message?: string } } }).response?.data?.message || 'Unknown error'
+          : error instanceof Error
+            ? error.message
+            : 'Unknown error';
+      setTestResult({
+        success: false,
+        message: t('notifications.error.testFailedMessage', { message: errMsg }),
+      });
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  const formatEvents = (events: string[]): string => {
+    return events
+      .map((e) => {
+        if (e === 's3:ObjectCreated:*') return t('notifications.form.objectCreated');
+        if (e === 's3:ObjectRemoved:*') return t('notifications.form.objectRemoved');
+        return e;
+      })
+      .join(', ');
+  };
+
+  const formatFilters = (entry: NotificationEntry): string => {
+    const parts: string[] = [];
+    if (entry.prefix) parts.push(`prefix: ${entry.prefix}`);
+    if (entry.suffix) parts.push(`suffix: ${entry.suffix}`);
+    return parts.length > 0 ? parts.join(', ') : '-';
+  };
+
+  return (
+    <Modal
+      className="standard-modal"
+      isOpen={isOpen}
+      onClose={handleClose}
+      aria-labelledby="bucket-notifications-modal-title"
+      variant="large"
+    >
+      <ModalHeader
+        labelId="bucket-notifications-modal-title"
+        title={t('notifications.title')}
+        description={`${bucketName} - ${t('notifications.description')}`}
+      />
+      <ModalBody>
+        {/* Notification list */}
+        {isLoading ? (
+          <>
+            <Skeleton width="100%" screenreaderText={t('translation:common.actions.loading')} />
+            <br />
+            <Skeleton width="100%" screenreaderText={t('translation:common.actions.loading')} />
+          </>
+        ) : notifications.length === 0 ? (
+          <EmptyState headingLevel="h4" icon={BellIcon} titleText={t('notifications.emptyState.title')}>
+            <EmptyStateBody>{t('notifications.emptyState.description')}</EmptyStateBody>
+          </EmptyState>
+        ) : (
+          <Table aria-label={t('notifications.title')} variant="compact">
+            <Thead>
+              <Tr>
+                <Th>{t('notifications.table.endpoint')}</Th>
+                <Th>{t('notifications.table.events')}</Th>
+                <Th>{t('notifications.table.filters')}</Th>
+                <Th screenReaderText={t('notifications.table.actions')} />
+              </Tr>
+            </Thead>
+            <Tbody>
+              {notifications.map((entry, index) => (
+                <Tr key={entry.id || index}>
+                  <Td dataLabel={t('notifications.table.endpoint')}>
+                    <Content component={ContentVariants.small} style={{ wordBreak: 'break-all' }}>
+                      {entry.endpoint}
+                    </Content>
+                  </Td>
+                  <Td dataLabel={t('notifications.table.events')}>{formatEvents(entry.events)}</Td>
+                  <Td dataLabel={t('notifications.table.filters')}>{formatFilters(entry)}</Td>
+                  <Td>
+                    {entry.id && (
+                      <div style={{ display: 'flex', gap: 'var(--pf-t--global--spacer--xs)' }}>
+                        <Tooltip content={<div>{t('tooltips.editNotification')}</div>}>
+                          <Button
+                            variant="plain"
+                            aria-label={t('notifications.form.editTitle')}
+                            onClick={() => handleEditClick(entry)}
+                          >
+                            <PencilAltIcon />
+                          </Button>
+                        </Tooltip>
+                        <Tooltip content={<div>{t('tooltips.deleteNotification')}</div>}>
+                          <Button
+                            variant="plain"
+                            aria-label={t('translation:common.actions.delete')}
+                            onClick={() => handleDeleteNotification(entry.id as string)}
+                          >
+                            <TrashIcon />
+                          </Button>
+                        </Tooltip>
+                      </div>
+                    )}
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        )}
+
+        {/* Add notification form */}
+        <ExpandableSection
+          toggleText={isEditMode ? t('notifications.form.editTitle') : t('notifications.form.addTitle')}
+          isExpanded={isFormExpanded}
+          onToggle={(_event, expanded) => {
+            if (!expanded) {
+              resetForm();
+            }
+            setIsFormExpanded(expanded);
+          }}
+          className="pf-u-margin-top-md"
+        >
+          <Form>
+            <FormGroup label={t('notifications.form.endpointLabel')} isRequired fieldId="notification-endpoint">
+              <TextInput
+                isRequired
+                type="url"
+                id="notification-endpoint"
+                placeholder={t('notifications.form.endpointPlaceholder')}
+                value={endpoint}
+                onChange={(_event, value) => setEndpoint(value)}
+                validated={endpoint && !/^https?:\/\/.+/.test(endpoint) ? 'error' : 'default'}
+              />
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>
+                    {endpoint && !/^https?:\/\/.+/.test(endpoint)
+                      ? t('notifications.error.endpointInvalid')
+                      : t('notifications.form.endpointHelperText')}
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+
+            <FormGroup label={t('notifications.form.eventsLabel')} isRequired fieldId="notification-events">
+              <Checkbox
+                label={t('notifications.form.objectCreated')}
+                id="event-object-created"
+                isChecked={objectCreated}
+                onChange={(_event, checked) => setObjectCreated(checked)}
+              />
+              <Checkbox
+                label={t('notifications.form.objectRemoved')}
+                id="event-object-removed"
+                isChecked={objectRemoved}
+                onChange={(_event, checked) => setObjectRemoved(checked)}
+              />
+              {!objectCreated && !objectRemoved && (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant="error">{t('notifications.error.eventsRequired')}</HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              )}
+            </FormGroup>
+
+            <FormGroup label={t('notifications.form.prefixLabel')} fieldId="notification-prefix">
+              <TextInput
+                type="text"
+                id="notification-prefix"
+                placeholder={t('notifications.form.prefixPlaceholder')}
+                value={prefix}
+                onChange={(_event, value) => setPrefix(value)}
+              />
+            </FormGroup>
+
+            <FormGroup label={t('notifications.form.suffixLabel')} fieldId="notification-suffix">
+              <TextInput
+                type="text"
+                id="notification-suffix"
+                placeholder={t('notifications.form.suffixPlaceholder')}
+                value={suffix}
+                onChange={(_event, value) => setSuffix(value)}
+              />
+            </FormGroup>
+
+            {testResult && (
+              <Alert
+                variant={testResult.success ? 'success' : 'danger'}
+                title={
+                  testResult.success ? t('notifications.success.testSuccess') : t('notifications.error.testFailed')
+                }
+                isInline
+              >
+                {testResult.message}
+              </Alert>
+            )}
+
+            <div className="pf-v6-l-flex" style={{ gap: 'var(--pf-t--global--spacer--sm)' }}>
+              <Button
+                variant="secondary"
+                onClick={handleTestEndpoint}
+                isLoading={isTesting}
+                isDisabled={!endpoint || !/^https?:\/\/.+/.test(endpoint) || isTesting}
+              >
+                {t('notifications.form.testButton')}
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleSaveNotification}
+                isLoading={isSaving}
+                isDisabled={!validateForm() || isSaving}
+              >
+                {isEditMode ? t('notifications.form.saveButton') : t('notifications.form.addButton')}
+              </Button>
+              {isEditMode && (
+                <Button variant="link" onClick={handleCancelEdit}>
+                  {t('notifications.form.cancelButton')}
+                </Button>
+              )}
+            </div>
+          </Form>
+        </ExpandableSection>
+      </ModalBody>
+    </Modal>
+  );
+};
+
+export default BucketNotificationsModal;

--- a/frontend/src/app/components/Buckets/Buckets.tsx
+++ b/frontend/src/app/components/Buckets/Buckets.tsx
@@ -28,11 +28,15 @@ import {
   Skeleton,
   TextInput,
   Tooltip,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 import {
   AngleLeftIcon,
   AngleRightIcon,
+  BellIcon,
   CloudIcon,
   CubesIcon,
   DatabaseIcon,
@@ -47,6 +51,7 @@ import { notifyApiError, notifySuccess, notifyWarning } from '@app/utils/notific
 import { getBucketNameRules, validateS3BucketName } from '@app/utils/validation';
 import { useModal, useStorageLocations } from '@app/hooks';
 import { MobileCardItem, MobileCardView, ResponsiveTableWrapper } from '@app/components/ResponsiveTable';
+import BucketNotificationsModal from './BucketNotificationsModal';
 
 class Bucket {
   Name: string;
@@ -120,6 +125,15 @@ const Buckets: React.FunctionComponent = () => {
   const handleNewBucketCancel = () => {
     setNewBucketName('');
     createBucketModal.close();
+  };
+
+  // Notifications modal handling
+  const notificationsModal = useModal();
+  const [notificationsBucket, setNotificationsBucket] = React.useState('');
+
+  const handleNotificationsClick = (name: string) => (_event: React.MouseEvent<HTMLButtonElement>) => {
+    setNotificationsBucket(name);
+    notificationsModal.open();
   };
 
   // Delete bucket handling
@@ -338,15 +352,30 @@ const Buckets: React.FunctionComponent = () => {
       },
     ],
     actions: row.type === 's3' && (
-      <Button
-        variant="danger"
-        size="sm"
-        onClick={handleDeleteBucketClick(row.name)}
-        isDisabled={!row.available}
-        aria-label={t('deleteModal.confirm') + ': ' + row.name}
-      >
-        <TrashIcon />
-      </Button>
+      <>
+        <Tooltip content={<div>{t('tooltips.notifications')}</div>}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleNotificationsClick(row.name)}
+            isDisabled={!row.available}
+            aria-label={t('notifications.actions.notifications') + ': ' + row.name}
+          >
+            <BellIcon />
+          </Button>
+        </Tooltip>{' '}
+        <Tooltip content={<div>{t('tooltips.deleteBucket')}</div>}>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={handleDeleteBucketClick(row.name)}
+            isDisabled={!row.available}
+            aria-label={t('deleteModal.confirm') + ': ' + row.name}
+          >
+            <TrashIcon />
+          </Button>
+        </Tooltip>
+      </>
     ),
     onClick: row.available ? () => navigate(`/browse/${row.id}`) : undefined,
     isDisabled: !row.available,
@@ -606,14 +635,39 @@ const Buckets: React.FunctionComponent = () => {
                           <Td className="bucket-column s4-hide-below-md">{row.owner || '-'}</Td>
                           <Td className="bucket-column align-right">
                             {row.type === 's3' && (
-                              <Button
-                                variant="danger"
-                                onClick={handleDeleteBucketClick(row.name)}
-                                isDisabled={!row.available}
-                                aria-label={t('deleteModal.confirm') + ': ' + row.name}
-                              >
-                                <TrashIcon />
-                              </Button>
+                              <ToolbarContent>
+                                <ToolbarGroup
+                                  variant="action-group-plain"
+                                  align={{ default: 'alignEnd' }}
+                                  gap={{ default: 'gapMd', md: 'gapMd' }}
+                                >
+                                  <ToolbarItem>
+                                    <Tooltip content={<div>{t('tooltips.notifications')}</div>}>
+                                      <Button
+                                        variant="secondary"
+                                        onClick={handleNotificationsClick(row.name)}
+                                        isDisabled={!row.available}
+                                        aria-label={t('notifications.actions.notifications') + ': ' + row.name}
+                                      >
+                                        <BellIcon />
+                                      </Button>
+                                    </Tooltip>
+                                  </ToolbarItem>
+                                  <ToolbarItem variant="separator" />
+                                  <ToolbarItem>
+                                    <Tooltip content={<div>{t('tooltips.deleteBucket')}</div>}>
+                                      <Button
+                                        variant="danger"
+                                        onClick={handleDeleteBucketClick(row.name)}
+                                        isDisabled={!row.available}
+                                        aria-label={t('deleteModal.confirm') + ': ' + row.name}
+                                      >
+                                        <TrashIcon />
+                                      </Button>
+                                    </Tooltip>
+                                  </ToolbarItem>
+                                </ToolbarGroup>
+                              </ToolbarContent>
                             )}
                           </Td>
                         </Tr>
@@ -752,6 +806,11 @@ const Buckets: React.FunctionComponent = () => {
           </Button>
         </ModalFooter>
       </Modal>
+      <BucketNotificationsModal
+        bucketName={notificationsBucket}
+        isOpen={notificationsModal.isOpen}
+        onClose={notificationsModal.close}
+      />
     </div>
   );
 };

--- a/frontend/src/app/components/StorageBrowser/StorageBrowser.tsx
+++ b/frontend/src/app/components/StorageBrowser/StorageBrowser.tsx
@@ -2242,14 +2242,16 @@ const StorageBrowser: React.FC = () => {
         },
       ],
       actions: (
-        <Button
-          variant="danger"
-          size="sm"
-          onClick={handleDeleteFolderClick(dir.path)}
-          aria-label={`Delete folder ${dir.name}`}
-        >
-          <TrashIcon />
-        </Button>
+        <Tooltip content={<div>{t('tooltips.deleteFolder')}</div>}>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={handleDeleteFolderClick(dir.path)}
+            aria-label={`Delete folder ${dir.name}`}
+          >
+            <TrashIcon />
+          </Button>
+        </Tooltip>
       ),
       selectable: true,
       isSelected: selectedItems.has(dir.path),
@@ -2746,14 +2748,16 @@ const StorageBrowser: React.FC = () => {
                             </Td>
                             <Td className="bucket-column s4-hide-below-sm">-</Td>
                             <Td className="bucket-column align-right">
-                              <Button
-                                variant="danger"
-                                className="button-file-control"
-                                onClick={handleDeleteFolderClick(dir.path)}
-                                aria-label={`Delete folder ${dir.name}`}
-                              >
-                                <TrashIcon />
-                              </Button>
+                              <Tooltip content={<div>{t('tooltips.deleteFolder')}</div>}>
+                                <Button
+                                  variant="danger"
+                                  className="button-file-control"
+                                  onClick={handleDeleteFolderClick(dir.path)}
+                                  aria-label={`Delete folder ${dir.name}`}
+                                >
+                                  <TrashIcon />
+                                </Button>
+                              </Tooltip>
                             </Td>
                           </Tr>
                         ))}

--- a/frontend/src/app/components/Transfer/DestinationPicker.tsx
+++ b/frontend/src/app/components/Transfer/DestinationPicker.tsx
@@ -47,7 +47,6 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({ isOpen, on
   const [newFolderName, setNewFolderName] = React.useState('');
   const [newFolderNameRulesVisibility, setNewFolderNameRulesVisibility] = React.useState(false);
 
-
   // Note: Storage locations are loaded by useStorageLocations hook
 
   // Load directories when location or path changes

--- a/frontend/src/app/utils/sseTickets.ts
+++ b/frontend/src/app/utils/sseTickets.ts
@@ -48,7 +48,7 @@ export async function requestSseTicket(
     });
 
     return response.data;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     console.error('[SSE Tickets] Failed to request ticket:', error);
 

--- a/frontend/src/i18n/locales/de/buckets.json
+++ b/frontend/src/i18n/locales/de/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "Ungültiger Bucket-Name",
     "invalidNameMessage": "Bucket-Name {{bucketName}} ist ungültig. Bitte überprüfen Sie die Regeln und versuchen Sie es erneut."
+  },
+  "notifications": {
+    "title": "Bucket-Benachrichtigungen",
+    "description": "Konfigurieren Sie Webhook-Benachrichtigungen für Ereignisse in diesem Bucket.",
+    "emptyState": {
+      "title": "Keine Benachrichtigungen konfiguriert",
+      "description": "Fügen Sie eine Benachrichtigung hinzu, um Webhook-Ereignisse zu erhalten, wenn Objekte in diesem Bucket erstellt oder gelöscht werden."
+    },
+    "table": {
+      "endpoint": "Endpunkt-URL",
+      "events": "Ereignisse",
+      "filters": "Filter",
+      "actions": "Aktionen"
+    },
+    "form": {
+      "addTitle": "Benachrichtigung hinzufügen",
+      "endpointLabel": "Endpunkt-URL",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "HTTP- oder HTTPS-URL, die Ereignisbenachrichtigungen empfängt",
+      "eventsLabel": "Ereignisse",
+      "objectCreated": "Objekt erstellt",
+      "objectRemoved": "Objekt gelöscht",
+      "prefixLabel": "Schlüsselpräfix-Filter",
+      "prefixPlaceholder": "z.B. uploads/",
+      "suffixLabel": "Schlüsselsuffix-Filter",
+      "suffixPlaceholder": "z.B. .jpg",
+      "addButton": "Benachrichtigung hinzufügen",
+      "testButton": "Endpunkt testen",
+      "editTitle": "Benachrichtigung bearbeiten",
+      "saveButton": "Änderungen speichern",
+      "cancelButton": "Bearbeitung abbrechen"
+    },
+    "deleteConfirm": {
+      "title": "Benachrichtigung entfernen?",
+      "message": "Dadurch werden keine Ereignisse mehr an diesen Endpunkt gesendet."
+    },
+    "success": {
+      "created": "Benachrichtigung hinzugefügt",
+      "createdMessage": "Benachrichtigungskonfiguration wurde erfolgreich aktualisiert.",
+      "deleted": "Benachrichtigung entfernt",
+      "deletedMessage": "Benachrichtigung wurde erfolgreich entfernt.",
+      "updated": "Benachrichtigung aktualisiert",
+      "updatedMessage": "Die Benachrichtigung wurde erfolgreich aktualisiert.",
+      "testSuccess": "Endpunkt erreichbar",
+      "testSuccessMessage": "Endpunkt hat mit Status {{statusCode}} geantwortet."
+    },
+    "error": {
+      "loadFailed": "Benachrichtigungen konnten nicht geladen werden",
+      "saveFailed": "Benachrichtigung konnte nicht gespeichert werden",
+      "deleteFailed": "Benachrichtigung konnte nicht entfernt werden",
+      "testFailed": "Endpunkt nicht erreichbar",
+      "testFailedMessage": "Der Endpunkt konnte nicht erreicht werden: {{message}}",
+      "endpointRequired": "Endpunkt-URL ist erforderlich",
+      "endpointInvalid": "Endpunkt muss mit http:// oder https:// beginnen",
+      "eventsRequired": "Mindestens ein Ereignistyp muss ausgewählt werden"
+    },
+    "actions": {
+      "notifications": "Benachrichtigungen"
+    }
+  },
+  "tooltips": {
+    "notifications": "Bucket-Benachrichtigungen verwalten.",
+    "deleteBucket": "Diesen Bucket löschen.",
+    "editNotification": "Diese Benachrichtigung bearbeiten.",
+    "deleteNotification": "Diese Benachrichtigung entfernen."
   }
 }

--- a/frontend/src/i18n/locales/de/storage-browser.json
+++ b/frontend/src/i18n/locales/de/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "Diese Datei anzeigen.",
     "downloadFile": "Diese Datei herunterladen.",
     "viewDetails": "Dateidetails und Tags anzeigen.",
-    "deleteFile": "Diese Datei löschen."
+    "deleteFile": "Diese Datei löschen.",
+    "deleteFolder": "Diesen Ordner löschen."
   },
   "pagination": {
     "loadMore": "Mehr laden",

--- a/frontend/src/i18n/locales/en/buckets.json
+++ b/frontend/src/i18n/locales/en/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "Invalid bucket name",
     "invalidNameMessage": "Bucket name {{bucketName}} is invalid. Please check the rules and try again."
+  },
+  "notifications": {
+    "title": "Bucket Notifications",
+    "description": "Configure webhook notifications for events in this bucket.",
+    "emptyState": {
+      "title": "No notifications configured",
+      "description": "Add a notification to receive webhook events when objects are created or deleted in this bucket."
+    },
+    "table": {
+      "endpoint": "Endpoint URL",
+      "events": "Events",
+      "filters": "Filters",
+      "actions": "Actions"
+    },
+    "form": {
+      "addTitle": "Add Notification",
+      "endpointLabel": "Endpoint URL",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "HTTP or HTTPS URL that will receive event notifications",
+      "eventsLabel": "Events",
+      "objectCreated": "Object Created",
+      "objectRemoved": "Object Removed",
+      "prefixLabel": "Key prefix filter",
+      "prefixPlaceholder": "e.g. uploads/",
+      "suffixLabel": "Key suffix filter",
+      "suffixPlaceholder": "e.g. .jpg",
+      "addButton": "Add Notification",
+      "testButton": "Test Endpoint",
+      "editTitle": "Edit Notification",
+      "saveButton": "Save Changes",
+      "cancelButton": "Cancel Editing"
+    },
+    "deleteConfirm": {
+      "title": "Remove notification?",
+      "message": "This will stop sending events to this endpoint."
+    },
+    "success": {
+      "created": "Notification added",
+      "createdMessage": "Notification configuration has been updated successfully.",
+      "deleted": "Notification removed",
+      "deletedMessage": "Notification has been removed successfully.",
+      "updated": "Notification updated",
+      "updatedMessage": "Notification has been updated successfully.",
+      "testSuccess": "Endpoint reachable",
+      "testSuccessMessage": "Endpoint responded with status {{statusCode}}."
+    },
+    "error": {
+      "loadFailed": "Failed to load notifications",
+      "saveFailed": "Failed to save notification",
+      "deleteFailed": "Failed to remove notification",
+      "testFailed": "Endpoint unreachable",
+      "testFailedMessage": "Could not reach the endpoint: {{message}}",
+      "endpointRequired": "Endpoint URL is required",
+      "endpointInvalid": "Endpoint must start with http:// or https://",
+      "eventsRequired": "At least one event type must be selected"
+    },
+    "actions": {
+      "notifications": "Notifications"
+    }
+  },
+  "tooltips": {
+    "notifications": "Manage bucket notifications.",
+    "deleteBucket": "Delete this bucket.",
+    "editNotification": "Edit this notification.",
+    "deleteNotification": "Remove this notification."
   }
 }

--- a/frontend/src/i18n/locales/en/storage-browser.json
+++ b/frontend/src/i18n/locales/en/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "View this file.",
     "downloadFile": "Download this file.",
     "viewDetails": "View file details and tags.",
-    "deleteFile": "Delete this file."
+    "deleteFile": "Delete this file.",
+    "deleteFolder": "Delete this folder."
   },
   "pagination": {
     "loadMore": "Load more",

--- a/frontend/src/i18n/locales/es/buckets.json
+++ b/frontend/src/i18n/locales/es/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "Nombre de bucket inválido",
     "invalidNameMessage": "El nombre de bucket {{bucketName}} es inválido. Verifique las reglas e inténtelo de nuevo."
+  },
+  "notifications": {
+    "title": "Notificaciones del bucket",
+    "description": "Configure notificaciones webhook para eventos en este bucket.",
+    "emptyState": {
+      "title": "No hay notificaciones configuradas",
+      "description": "Agregue una notificación para recibir eventos webhook cuando se creen o eliminen objetos en este bucket."
+    },
+    "table": {
+      "endpoint": "URL del endpoint",
+      "events": "Eventos",
+      "filters": "Filtros",
+      "actions": "Acciones"
+    },
+    "form": {
+      "addTitle": "Agregar notificación",
+      "endpointLabel": "URL del endpoint",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "URL HTTP o HTTPS que recibirá las notificaciones de eventos",
+      "eventsLabel": "Eventos",
+      "objectCreated": "Objeto creado",
+      "objectRemoved": "Objeto eliminado",
+      "prefixLabel": "Filtro de prefijo de clave",
+      "prefixPlaceholder": "ej. uploads/",
+      "suffixLabel": "Filtro de sufijo de clave",
+      "suffixPlaceholder": "ej. .jpg",
+      "addButton": "Agregar notificación",
+      "testButton": "Probar endpoint",
+      "editTitle": "Editar notificación",
+      "saveButton": "Guardar cambios",
+      "cancelButton": "Cancelar edición"
+    },
+    "deleteConfirm": {
+      "title": "¿Eliminar notificación?",
+      "message": "Esto dejará de enviar eventos a este endpoint."
+    },
+    "success": {
+      "created": "Notificación agregada",
+      "createdMessage": "La configuración de notificaciones se ha actualizado correctamente.",
+      "deleted": "Notificación eliminada",
+      "deletedMessage": "La notificación se ha eliminado correctamente.",
+      "updated": "Notificación actualizada",
+      "updatedMessage": "La notificación se ha actualizado correctamente.",
+      "testSuccess": "Endpoint accesible",
+      "testSuccessMessage": "El endpoint respondió con estado {{statusCode}}."
+    },
+    "error": {
+      "loadFailed": "Error al cargar las notificaciones",
+      "saveFailed": "Error al guardar la notificación",
+      "deleteFailed": "Error al eliminar la notificación",
+      "testFailed": "Endpoint inaccesible",
+      "testFailedMessage": "No se pudo alcanzar el endpoint: {{message}}",
+      "endpointRequired": "La URL del endpoint es obligatoria",
+      "endpointInvalid": "El endpoint debe comenzar con http:// o https://",
+      "eventsRequired": "Se debe seleccionar al menos un tipo de evento"
+    },
+    "actions": {
+      "notifications": "Notificaciones"
+    }
+  },
+  "tooltips": {
+    "notifications": "Gestionar notificaciones del bucket.",
+    "deleteBucket": "Eliminar este bucket.",
+    "editNotification": "Editar esta notificación.",
+    "deleteNotification": "Eliminar esta notificación."
   }
 }

--- a/frontend/src/i18n/locales/es/storage-browser.json
+++ b/frontend/src/i18n/locales/es/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "Ver este archivo.",
     "downloadFile": "Descargar este archivo.",
     "viewDetails": "Ver detalles y etiquetas del archivo.",
-    "deleteFile": "Eliminar este archivo."
+    "deleteFile": "Eliminar este archivo.",
+    "deleteFolder": "Eliminar esta carpeta."
   },
   "pagination": {
     "loadMore": "Cargar más",

--- a/frontend/src/i18n/locales/fr/buckets.json
+++ b/frontend/src/i18n/locales/fr/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "Nom de bucket invalide",
     "invalidNameMessage": "Le nom de bucket {{bucketName}} est invalide. Veuillez vérifier les règles et réessayer."
+  },
+  "notifications": {
+    "title": "Notifications du bucket",
+    "description": "Configurez des notifications webhook pour les événements de ce bucket.",
+    "emptyState": {
+      "title": "Aucune notification configurée",
+      "description": "Ajoutez une notification pour recevoir des événements webhook lorsque des objets sont créés ou supprimés dans ce bucket."
+    },
+    "table": {
+      "endpoint": "URL du point de terminaison",
+      "events": "Événements",
+      "filters": "Filtres",
+      "actions": "Actions"
+    },
+    "form": {
+      "addTitle": "Ajouter une notification",
+      "endpointLabel": "URL du point de terminaison",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "URL HTTP ou HTTPS qui recevra les notifications d'événements",
+      "eventsLabel": "Événements",
+      "objectCreated": "Objet créé",
+      "objectRemoved": "Objet supprimé",
+      "prefixLabel": "Filtre de préfixe de clé",
+      "prefixPlaceholder": "ex. uploads/",
+      "suffixLabel": "Filtre de suffixe de clé",
+      "suffixPlaceholder": "ex. .jpg",
+      "addButton": "Ajouter une notification",
+      "testButton": "Tester le point de terminaison",
+      "editTitle": "Modifier la notification",
+      "saveButton": "Enregistrer les modifications",
+      "cancelButton": "Annuler la modification"
+    },
+    "deleteConfirm": {
+      "title": "Supprimer la notification ?",
+      "message": "Cela arrêtera l'envoi d'événements à ce point de terminaison."
+    },
+    "success": {
+      "created": "Notification ajoutée",
+      "createdMessage": "La configuration des notifications a été mise à jour avec succès.",
+      "deleted": "Notification supprimée",
+      "deletedMessage": "La notification a été supprimée avec succès.",
+      "updated": "Notification mise à jour",
+      "updatedMessage": "La notification a été mise à jour avec succès.",
+      "testSuccess": "Point de terminaison accessible",
+      "testSuccessMessage": "Le point de terminaison a répondu avec le statut {{statusCode}}."
+    },
+    "error": {
+      "loadFailed": "Échec du chargement des notifications",
+      "saveFailed": "Échec de l'enregistrement de la notification",
+      "deleteFailed": "Échec de la suppression de la notification",
+      "testFailed": "Point de terminaison inaccessible",
+      "testFailedMessage": "Impossible d'atteindre le point de terminaison : {{message}}",
+      "endpointRequired": "L'URL du point de terminaison est requise",
+      "endpointInvalid": "Le point de terminaison doit commencer par http:// ou https://",
+      "eventsRequired": "Au moins un type d'événement doit être sélectionné"
+    },
+    "actions": {
+      "notifications": "Notifications"
+    }
+  },
+  "tooltips": {
+    "notifications": "Gérer les notifications du bucket.",
+    "deleteBucket": "Supprimer ce bucket.",
+    "editNotification": "Modifier cette notification.",
+    "deleteNotification": "Supprimer cette notification."
   }
 }

--- a/frontend/src/i18n/locales/fr/storage-browser.json
+++ b/frontend/src/i18n/locales/fr/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "Afficher ce fichier.",
     "downloadFile": "Télécharger ce fichier.",
     "viewDetails": "Voir les détails et tags du fichier.",
-    "deleteFile": "Supprimer ce fichier."
+    "deleteFile": "Supprimer ce fichier.",
+    "deleteFolder": "Supprimer ce dossier."
   },
   "pagination": {
     "loadMore": "Charger plus",

--- a/frontend/src/i18n/locales/it/buckets.json
+++ b/frontend/src/i18n/locales/it/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "Nome del bucket non valido",
     "invalidNameMessage": "Il nome del bucket {{bucketName}} non è valido. Controlla le regole e riprova."
+  },
+  "notifications": {
+    "title": "Notifiche del bucket",
+    "description": "Configura le notifiche webhook per gli eventi in questo bucket.",
+    "emptyState": {
+      "title": "Nessuna notifica configurata",
+      "description": "Aggiungi una notifica per ricevere eventi webhook quando gli oggetti vengono creati o eliminati in questo bucket."
+    },
+    "table": {
+      "endpoint": "URL dell'endpoint",
+      "events": "Eventi",
+      "filters": "Filtri",
+      "actions": "Azioni"
+    },
+    "form": {
+      "addTitle": "Aggiungi notifica",
+      "endpointLabel": "URL dell'endpoint",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "URL HTTP o HTTPS che riceverà le notifiche degli eventi",
+      "eventsLabel": "Eventi",
+      "objectCreated": "Oggetto creato",
+      "objectRemoved": "Oggetto eliminato",
+      "prefixLabel": "Filtro prefisso chiave",
+      "prefixPlaceholder": "es. uploads/",
+      "suffixLabel": "Filtro suffisso chiave",
+      "suffixPlaceholder": "es. .jpg",
+      "addButton": "Aggiungi notifica",
+      "testButton": "Testa endpoint",
+      "editTitle": "Modifica notifica",
+      "saveButton": "Salva modifiche",
+      "cancelButton": "Annulla modifica"
+    },
+    "deleteConfirm": {
+      "title": "Rimuovere la notifica?",
+      "message": "Questo interromperà l'invio di eventi a questo endpoint."
+    },
+    "success": {
+      "created": "Notifica aggiunta",
+      "createdMessage": "La configurazione delle notifiche è stata aggiornata con successo.",
+      "deleted": "Notifica rimossa",
+      "deletedMessage": "La notifica è stata rimossa con successo.",
+      "updated": "Notifica aggiornata",
+      "updatedMessage": "La notifica è stata aggiornata con successo.",
+      "testSuccess": "Endpoint raggiungibile",
+      "testSuccessMessage": "L'endpoint ha risposto con stato {{statusCode}}."
+    },
+    "error": {
+      "loadFailed": "Impossibile caricare le notifiche",
+      "saveFailed": "Impossibile salvare la notifica",
+      "deleteFailed": "Impossibile rimuovere la notifica",
+      "testFailed": "Endpoint non raggiungibile",
+      "testFailedMessage": "Impossibile raggiungere l'endpoint: {{message}}",
+      "endpointRequired": "L'URL dell'endpoint è obbligatorio",
+      "endpointInvalid": "L'endpoint deve iniziare con http:// o https://",
+      "eventsRequired": "È necessario selezionare almeno un tipo di evento"
+    },
+    "actions": {
+      "notifications": "Notifiche"
+    }
+  },
+  "tooltips": {
+    "notifications": "Gestisci le notifiche del bucket.",
+    "deleteBucket": "Elimina questo bucket.",
+    "editNotification": "Modifica questa notifica.",
+    "deleteNotification": "Rimuovi questa notifica."
   }
 }

--- a/frontend/src/i18n/locales/it/storage-browser.json
+++ b/frontend/src/i18n/locales/it/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "Visualizza questo file.",
     "downloadFile": "Scarica questo file.",
     "viewDetails": "Visualizza dettagli e tag del file.",
-    "deleteFile": "Elimina questo file."
+    "deleteFile": "Elimina questo file.",
+    "deleteFolder": "Elimina questa cartella."
   },
   "pagination": {
     "loadMore": "Carica altri",

--- a/frontend/src/i18n/locales/ja/buckets.json
+++ b/frontend/src/i18n/locales/ja/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "無効な bucket 名",
     "invalidNameMessage": "Bucket 名 {{bucketName}} は無効です。規則を確認してもう一度お試しください。"
+  },
+  "notifications": {
+    "title": "Bucket 通知",
+    "description": "この bucket のイベントに対する Webhook 通知を設定します。",
+    "emptyState": {
+      "title": "通知が設定されていません",
+      "description": "この bucket でオブジェクトが作成または削除されたときに Webhook イベントを受信するには、通知を追加してください。"
+    },
+    "table": {
+      "endpoint": "エンドポイント URL",
+      "events": "イベント",
+      "filters": "フィルター",
+      "actions": "アクション"
+    },
+    "form": {
+      "addTitle": "通知を追加",
+      "endpointLabel": "エンドポイント URL",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "イベント通知を受信する HTTP または HTTPS の URL",
+      "eventsLabel": "イベント",
+      "objectCreated": "オブジェクト作成",
+      "objectRemoved": "オブジェクト削除",
+      "prefixLabel": "キープレフィックスフィルター",
+      "prefixPlaceholder": "例: uploads/",
+      "suffixLabel": "キーサフィックスフィルター",
+      "suffixPlaceholder": "例: .jpg",
+      "addButton": "通知を追加",
+      "testButton": "エンドポイントをテスト",
+      "editTitle": "通知を編集",
+      "saveButton": "変更を保存",
+      "cancelButton": "編集をキャンセル"
+    },
+    "deleteConfirm": {
+      "title": "通知を削除しますか？",
+      "message": "このエンドポイントへのイベント送信が停止されます。"
+    },
+    "success": {
+      "created": "通知を追加しました",
+      "createdMessage": "通知設定が正常に更新されました。",
+      "deleted": "通知を削除しました",
+      "deletedMessage": "通知が正常に削除されました。",
+      "updated": "通知が更新されました",
+      "updatedMessage": "通知が正常に更新されました。",
+      "testSuccess": "エンドポイント到達可能",
+      "testSuccessMessage": "エンドポイントがステータス {{statusCode}} で応答しました。"
+    },
+    "error": {
+      "loadFailed": "通知の読み込みに失敗しました",
+      "saveFailed": "通知の保存に失敗しました",
+      "deleteFailed": "通知の削除に失敗しました",
+      "testFailed": "エンドポイント到達不能",
+      "testFailedMessage": "エンドポイントに到達できませんでした: {{message}}",
+      "endpointRequired": "エンドポイント URL は必須です",
+      "endpointInvalid": "エンドポイントは http:// または https:// で始まる必要があります",
+      "eventsRequired": "少なくとも 1 つのイベントタイプを選択してください"
+    },
+    "actions": {
+      "notifications": "通知"
+    }
+  },
+  "tooltips": {
+    "notifications": "バケットの通知を管理します。",
+    "deleteBucket": "このバケットを削除します。",
+    "editNotification": "この通知を編集します。",
+    "deleteNotification": "この通知を削除します。"
   }
 }

--- a/frontend/src/i18n/locales/ja/storage-browser.json
+++ b/frontend/src/i18n/locales/ja/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "このファイルを表示します。",
     "downloadFile": "このファイルをダウンロードします。",
     "viewDetails": "ファイルの詳細とタグを表示します。",
-    "deleteFile": "このファイルを削除します。"
+    "deleteFile": "このファイルを削除します。",
+    "deleteFolder": "このフォルダーを削除します。"
   },
   "pagination": {
     "loadMore": "さらに読み込む",

--- a/frontend/src/i18n/locales/ko/buckets.json
+++ b/frontend/src/i18n/locales/ko/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "잘못된 bucket 이름",
     "invalidNameMessage": "Bucket 이름 {{bucketName}}이(가) 유효하지 않습니다. 규칙을 확인하고 다시 시도하세요."
+  },
+  "notifications": {
+    "title": "Bucket 알림",
+    "description": "이 bucket의 이벤트에 대한 웹훅 알림을 구성합니다.",
+    "emptyState": {
+      "title": "구성된 알림이 없습니다",
+      "description": "이 bucket에서 객체가 생성되거나 삭제될 때 웹훅 이벤트를 수신하려면 알림을 추가하세요."
+    },
+    "table": {
+      "endpoint": "엔드포인트 URL",
+      "events": "이벤트",
+      "filters": "필터",
+      "actions": "작업"
+    },
+    "form": {
+      "addTitle": "알림 추가",
+      "endpointLabel": "엔드포인트 URL",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "이벤트 알림을 수신할 HTTP 또는 HTTPS URL",
+      "eventsLabel": "이벤트",
+      "objectCreated": "객체 생성",
+      "objectRemoved": "객체 삭제",
+      "prefixLabel": "키 접두사 필터",
+      "prefixPlaceholder": "예: uploads/",
+      "suffixLabel": "키 접미사 필터",
+      "suffixPlaceholder": "예: .jpg",
+      "addButton": "알림 추가",
+      "testButton": "엔드포인트 테스트",
+      "editTitle": "알림 편집",
+      "saveButton": "변경 사항 저장",
+      "cancelButton": "편집 취소"
+    },
+    "deleteConfirm": {
+      "title": "알림을 제거하시겠습니까?",
+      "message": "이 엔드포인트로의 이벤트 전송이 중지됩니다."
+    },
+    "success": {
+      "created": "알림 추가됨",
+      "createdMessage": "알림 구성이 성공적으로 업데이트되었습니다.",
+      "deleted": "알림 제거됨",
+      "deletedMessage": "알림이 성공적으로 제거되었습니다.",
+      "updated": "알림 업데이트됨",
+      "updatedMessage": "알림이 성공적으로 업데이트되었습니다.",
+      "testSuccess": "엔드포인트 도달 가능",
+      "testSuccessMessage": "엔드포인트가 상태 {{statusCode}}으로 응답했습니다."
+    },
+    "error": {
+      "loadFailed": "알림을 불러오지 못했습니다",
+      "saveFailed": "알림을 저장하지 못했습니다",
+      "deleteFailed": "알림을 제거하지 못했습니다",
+      "testFailed": "엔드포인트 도달 불가",
+      "testFailedMessage": "엔드포인트에 도달할 수 없습니다: {{message}}",
+      "endpointRequired": "엔드포인트 URL은 필수입니다",
+      "endpointInvalid": "엔드포인트는 http:// 또는 https://로 시작해야 합니다",
+      "eventsRequired": "최소 하나의 이벤트 유형을 선택해야 합니다"
+    },
+    "actions": {
+      "notifications": "알림"
+    }
+  },
+  "tooltips": {
+    "notifications": "버킷 알림을 관리합니다.",
+    "deleteBucket": "이 버킷을 삭제합니다.",
+    "editNotification": "이 알림을 편집합니다.",
+    "deleteNotification": "이 알림을 삭제합니다."
   }
 }

--- a/frontend/src/i18n/locales/ko/storage-browser.json
+++ b/frontend/src/i18n/locales/ko/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "이 파일을 봅니다.",
     "downloadFile": "이 파일을 다운로드합니다.",
     "viewDetails": "파일 상세 정보 및 태그를 봅니다.",
-    "deleteFile": "이 파일을 삭제합니다."
+    "deleteFile": "이 파일을 삭제합니다.",
+    "deleteFolder": "이 폴더를 삭제합니다."
   },
   "pagination": {
     "loadMore": "더 불러오기",

--- a/frontend/src/i18n/locales/zh/buckets.json
+++ b/frontend/src/i18n/locales/zh/buckets.json
@@ -61,5 +61,70 @@
   "validation": {
     "invalidName": "无效的 bucket 名称",
     "invalidNameMessage": "Bucket 名称 {{bucketName}} 无效。请检查规则后重试。"
+  },
+  "notifications": {
+    "title": "Bucket 通知",
+    "description": "为此 bucket 中的事件配置 Webhook 通知。",
+    "emptyState": {
+      "title": "未配置通知",
+      "description": "添加通知以在此 bucket 中创建或删除对象时接收 Webhook 事件。"
+    },
+    "table": {
+      "endpoint": "端点 URL",
+      "events": "事件",
+      "filters": "过滤器",
+      "actions": "操作"
+    },
+    "form": {
+      "addTitle": "添加通知",
+      "endpointLabel": "端点 URL",
+      "endpointPlaceholder": "https://example.com/webhook",
+      "endpointHelperText": "将接收事件通知的 HTTP 或 HTTPS URL",
+      "eventsLabel": "事件",
+      "objectCreated": "对象已创建",
+      "objectRemoved": "对象已删除",
+      "prefixLabel": "键前缀过滤器",
+      "prefixPlaceholder": "例如 uploads/",
+      "suffixLabel": "键后缀过滤器",
+      "suffixPlaceholder": "例如 .jpg",
+      "addButton": "添加通知",
+      "testButton": "测试端点",
+      "editTitle": "编辑通知",
+      "saveButton": "保存更改",
+      "cancelButton": "取消编辑"
+    },
+    "deleteConfirm": {
+      "title": "删除通知？",
+      "message": "这将停止向此端点发送事件。"
+    },
+    "success": {
+      "created": "通知已添加",
+      "createdMessage": "通知配置已成功更新。",
+      "deleted": "通知已删除",
+      "deletedMessage": "通知已成功删除。",
+      "updated": "通知已更新",
+      "updatedMessage": "通知已成功更新。",
+      "testSuccess": "端点可达",
+      "testSuccessMessage": "端点响应状态为 {{statusCode}}。"
+    },
+    "error": {
+      "loadFailed": "加载通知失败",
+      "saveFailed": "保存通知失败",
+      "deleteFailed": "删除通知失败",
+      "testFailed": "端点不可达",
+      "testFailedMessage": "无法到达端点：{{message}}",
+      "endpointRequired": "端点 URL 为必填项",
+      "endpointInvalid": "端点必须以 http:// 或 https:// 开头",
+      "eventsRequired": "至少需要选择一个事件类型"
+    },
+    "actions": {
+      "notifications": "通知"
+    }
+  },
+  "tooltips": {
+    "notifications": "管理存储桶通知。",
+    "deleteBucket": "删除此存储桶。",
+    "editNotification": "编辑此通知。",
+    "deleteNotification": "删除此通知。"
   }
 }

--- a/frontend/src/i18n/locales/zh/storage-browser.json
+++ b/frontend/src/i18n/locales/zh/storage-browser.json
@@ -224,7 +224,8 @@
     "viewFile": "查看此文件。",
     "downloadFile": "下载此文件。",
     "viewDetails": "查看文件详情和标签。",
-    "deleteFile": "删除此文件。"
+    "deleteFile": "删除此文件。",
+    "deleteFolder": "删除此文件夹。"
   },
   "pagination": {
     "loadMore": "加载更多",

--- a/kubernetes/s4-ingress-s3.yaml
+++ b/kubernetes/s4-ingress-s3.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/component: storage
 spec:
   rules:
-    - host: s3.s4.example.com  # Change to your actual hostname
+    - host: s3.s4.example.com # Change to your actual hostname
       http:
         paths:
           - path: /

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "s4",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "s4",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s4",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Super Simple Storage Service - Lightweight S3 solution with web UI",
   "author": "Red Hat AI Services BU",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Add a filesystem-based bucket notification system that watches for S3 object changes and dispatches events to configured webhook endpoints
- Backend: notification CRUD API with validation, filesystem watcher, webhook dispatcher, async store with write mutex, audit logging
- Frontend: BucketNotificationsModal with create/edit/delete, tooltips on action icons, i18n for all 8 locales
- Comprehensive docs: API reference, user guide, FAQ, troubleshooting

## Test plan

- [x] Backend unit tests pass (13 tests including validation, 404, non-2xx warning)
- [x] TypeScript compiles cleanly (both backend and frontend)
- [x] ESLint passes with no warnings
- [x] Manual: create/edit/delete notification via modal
- [x] Manual: test-endpoint returns success with warning for non-2xx
- [x] Manual: webhook fires on object upload/delete
- [x] Manual: notifications cleaned up on bucket deletion